### PR TITLE
refactor: rename commands to have host in them

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In addition to native healthchecks, `docker-orchestrate` supports extended funct
 
 ### Script Healthchecks
 
-The tool supports an extended healthcheck mechanism via the `x-healthcheck-command` field.
+The tool supports an extended healthcheck mechanism via the `x-healthcheck-host-command` field.
 
 ```yaml
 services:
@@ -64,7 +64,7 @@ services:
       update_config:
         parallelism: 1
         order: start-first
-        x-healthcheck-command: |
+        x-healthcheck-host-command: |
           curl -f http://{{.ContainerIP}}:8080/health
 ```
 
@@ -72,22 +72,22 @@ The script healthcheck runs after the standard Docker healthcheck (if defined) s
 
 ### Stop Commands
 
-The tool also supports `x-pre-stop-command` and `x-post-stop-command` fields, which are executed before and after a container is terminated, respectively (e.g., during a rolling update or scale down).
+The tool also supports `x-pre-stop-host-command` and `x-post-stop-host-command` fields, which are executed before and after a container is terminated, respectively (e.g., during a rolling update or scale down).
 
 ```yaml
 services:
   web:
     deploy:
       update_config:
-        x-pre-stop-command: |
+        x-pre-stop-host-command: |
           curl -f http://{{.ContainerIP}}:8080/shutdown
-        x-post-stop-command: |
+        x-post-stop-host-command: |
           echo "Container {{.ContainerShortID}} has been stopped"
 ```
 
 ### Script Templating
 
-Both `x-healthcheck-command`, `x-pre-stop-command`, and `x-post-stop-command` are treated as Go templates and have access to:
+Both `x-healthcheck-host-command`, `x-pre-stop-host-command`, and `x-post-stop-host-command` are treated as Go templates and have access to:
 
 - `.ContainerID`: Full ID of the container.
 - `.ContainerShortID`: First 12 characters of the container ID.
@@ -97,6 +97,6 @@ Both `x-healthcheck-command`, `x-pre-stop-command`, and `x-post-stop-command` ar
 ## Caveats
 
 - **Single-node focus**: `docker orchestrate` is designed for use with Docker Compose on a single Docker Engine. It is not intended for use with Docker Swarm.
-- **Script healthcheck locality**: The `x-healthcheck-command` script is executed on the host machine where the `docker orchestrate` command is run, not within the container itself. Use the `HEALTHCHECK` directive to run healthchecks within a container.
+- **Script healthcheck locality**: The `x-healthcheck-host-command` script is executed on the host machine where the `docker orchestrate` command is run, not within the container itself. Use the `HEALTHCHECK` directive to run healthchecks within a container.
 - **Network connectivity**: For script healthchecks that rely on `.ContainerIP`, the host machine must have direct network access to the container's IP address (e.g., via the Docker bridge network).
 - **Failure Action**: Currently, only the `pause` `failure_action` is supported. Other `failure_action` values will cause `docker orchestrate` to exit non-zero. If a deployment fails, `docker orchestrate` will stop and leave the system in its current state.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,15 +11,20 @@ services:
         monitor: 5s
         max_failure_ratio: 0.1
         order: start-first
-        x-healthcheck-command: |
+        x-healthcheck-host-command: |
           echo "Healthcheck for container {{ .ContainerShortID }} failed!" >&2
           exit 0
-        x-pre-stop-command: |
+        x-pre-stop-host-command: |
           echo "This can be used to interact with the container before it is stopped by the docker api"
           echo 'Stop command running on host'
           exit 0
-        x-post-stop-command: |
+        x-post-stop-host-command: |
           echo "This can be used to interact with the container after it is stopped by the docker api"
           echo "It can also be used to update other systems that are tracking containers within the docker compose project"
           echo 'Post-stop command running on host'
+          exit 0
+        x-post-start-command: |
+          echo "This can be used to interact with the container after it is started by the docker api"
+          echo "It can also be used to update other systems that are tracking containers within the docker compose project"
+          echo 'Post-start command running on host'
           exit 0

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -177,18 +177,18 @@ func DeployService(input DeployServiceInput) error {
 		order = string(updateConfig.Order)
 	}
 
-	healthcheckCommand := ""
-	preStopCommand := ""
-	postStopCommand := ""
+	healthcheckHostCommand := ""
+	preStopHostCommand := ""
+	postStopHostCommand := ""
 	if updateConfig.Extensions != nil {
-		if cmd, ok := updateConfig.Extensions["x-healthcheck-command"].(string); ok {
-			healthcheckCommand = cmd
+		if cmd, ok := updateConfig.Extensions["x-healthcheck-host-command"].(string); ok {
+			healthcheckHostCommand = cmd
 		}
-		if cmd, ok := updateConfig.Extensions["x-pre-stop-command"].(string); ok {
-			preStopCommand = cmd
+		if cmd, ok := updateConfig.Extensions["x-pre-stop-host-command"].(string); ok {
+			preStopHostCommand = cmd
 		}
-		if cmd, ok := updateConfig.Extensions["x-post-stop-command"].(string); ok {
-			postStopCommand = cmd
+		if cmd, ok := updateConfig.Extensions["x-post-stop-host-command"].(string); ok {
+			postStopHostCommand = cmd
 		}
 	}
 
@@ -214,17 +214,17 @@ func DeployService(input DeployServiceInput) error {
 	// Scale down if needed (before rolling update)
 	if len(currentContainers) > replicas {
 		err := scaleDownContainers(ctx, ScaleDownContainersInput{
-			Client:            input.Client,
-			ComposeFile:       input.ComposeFile,
-			CurrentContainers: currentContainers,
-			CurrentReplicas:   len(currentContainers),
-			DesiredReplicas:   replicas,
-			Executor:          executor,
-			Logger:            input.Logger,
-			ProjectName:       input.ProjectName,
-			ServiceName:       input.ServiceName,
-			PreStopCommand:    preStopCommand,
-			PostStopCommand:   postStopCommand,
+			Client:              input.Client,
+			ComposeFile:         input.ComposeFile,
+			CurrentContainers:   currentContainers,
+			CurrentReplicas:     len(currentContainers),
+			DesiredReplicas:     replicas,
+			Executor:            executor,
+			Logger:              input.Logger,
+			PostStopHostCommand: postStopHostCommand,
+			PreStopHostCommand:  preStopHostCommand,
+			ProjectName:         input.ProjectName,
+			ServiceName:         input.ServiceName,
 		})
 		if err != nil {
 			return err
@@ -253,25 +253,25 @@ func DeployService(input DeployServiceInput) error {
 	var rollingUpdateOutput RollingUpdateOutput
 	if len(containersToUpdate) > 0 {
 		rollingUpdateOutput, err = rollingUpdateContainers(ctx, RollingUpdateInput{
-			Client:             input.Client,
-			ComposeFile:        input.ComposeFile,
-			ContainersToUpdate: containersToUpdate,
-			CurrentReplicas:    len(containersToUpdate),
-			Delay:              delay,
-			DesiredReplicas:    replicas,
-			Executor:           executor,
-			FailureAction:      updateConfig.FailureAction,
-			HealthcheckCommand: healthcheckCommand,
-			Logger:             input.Logger,
-			MaxFailureRatio:    maxFailureRatio,
-			Monitor:            monitor,
-			Order:              order,
-			Parallelism:        parallelism,
-			ProjectDir:         projectDir,
-			ProjectName:        input.ProjectName,
-			ServiceName:        input.ServiceName,
-			PreStopCommand:     preStopCommand,
-			PostStopCommand:    postStopCommand,
+			Client:              input.Client,
+			ComposeFile:         input.ComposeFile,
+			ContainersToUpdate:  containersToUpdate,
+			CurrentReplicas:     len(containersToUpdate),
+			Delay:               delay,
+			DesiredReplicas:     replicas,
+			Executor:            executor,
+			FailureAction:       updateConfig.FailureAction,
+			HealthcheckCommand:  healthcheckHostCommand,
+			Logger:              input.Logger,
+			MaxFailureRatio:     maxFailureRatio,
+			Monitor:             monitor,
+			Order:               order,
+			Parallelism:         parallelism,
+			PostStopHostCommand: postStopHostCommand,
+			PreStopHostCommand:  preStopHostCommand,
+			ProjectDir:          projectDir,
+			ProjectName:         input.ProjectName,
+			ServiceName:         input.ServiceName,
 		})
 		if err != nil {
 			return fmt.Errorf("error rolling update containers: %v", err)
@@ -292,24 +292,24 @@ func DeployService(input DeployServiceInput) error {
 	// Scale up if needed (only after existing containers are replaced)
 	if len(updatedContainers) < replicas {
 		err := scaleUpContainers(ctx, ScaleUpContainersInput{
-			Client:             input.Client,
-			ComposeFile:        input.ComposeFile,
-			CurrentReplicas:    len(updatedContainers),
-			Delay:              delay,
-			DesiredReplicas:    replicas,
-			Executor:           executor,
-			ExistingContainers: updatedContainers,
-			FailureAction:      string(updateConfig.FailureAction),
-			HealthcheckCommand: healthcheckCommand,
-			Logger:             input.Logger,
-			MaxFailureRatio:    maxFailureRatio,
-			Monitor:            monitor,
-			Parallelism:        parallelism,
-			ProjectDir:         projectDir,
-			ProjectName:        input.ProjectName,
-			ServiceName:        input.ServiceName,
-			PreStopCommand:     preStopCommand,
-			PostStopCommand:    postStopCommand,
+			Client:              input.Client,
+			ComposeFile:         input.ComposeFile,
+			CurrentReplicas:     len(updatedContainers),
+			Delay:               delay,
+			DesiredReplicas:     replicas,
+			Executor:            executor,
+			ExistingContainers:  updatedContainers,
+			FailureAction:       string(updateConfig.FailureAction),
+			HealthcheckCommand:  healthcheckHostCommand,
+			Logger:              input.Logger,
+			MaxFailureRatio:     maxFailureRatio,
+			Monitor:             monitor,
+			Parallelism:         parallelism,
+			PostStopHostCommand: postStopHostCommand,
+			PreStopHostCommand:  preStopHostCommand,
+			ProjectDir:          projectDir,
+			ProjectName:         input.ProjectName,
+			ServiceName:         input.ServiceName,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Add the word 'host' into the extensions to denote that the commands run on the host - and therefore may have elevated permissions to things on disk.

Also call the scripts directly vs having them be run through small wrapper scripts.