### PR TITLE
fix: skip provider services

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ When a service has this label set to `"true"`, it will be skipped during deploym
 
 **Note**: The label value must be exactly the string `"true"` (case-sensitive). Other values like `"false"`, `"yes"`, or `"1"` will not trigger skipping.
 
+### Skipping Provider Services
+
+Services that use external providers (defined via the `provider` field) are automatically skipped during deployment. Provider services are typically managed by external systems (like cloud providers) and should not be deployed by `docker-orchestrate`.
+
+```yaml
+services:
+  database:
+    provider:
+      type: awesomecloud
+      options:
+        type: mysql
+        foo: bar
+  web:
+    image: nginx:alpine
+    # This service will be deployed normally
+```
+
+Provider services are skipped before any other skip checks (labels or database detection), ensuring they are never deployed regardless of other configuration.
+
 ## Caveats
 
 - **Single-node focus**: `docker orchestrate` is designed for use with Docker Compose on a single Docker Engine. It is not intended for use with Docker Swarm.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,3 +48,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
+  database:
+    provider:
+      type: awesomecloud
+      options:
+        type: mysql
+        foo: bar

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -369,6 +369,12 @@ func OrderServices(ctx context.Context, input DeployProjectInput) ([]string, err
 
 // shouldSkipService returns true if the service should be skipped
 func shouldSkipService(service *types.ServiceConfig, shouldSkipDatabases bool, logger *command.ZerologUi) bool {
+	// skip provider services
+	if service.Provider != nil {
+		logger.Info(fmt.Sprintf("Skipping provider service: service=%s", service.Name))
+		return true
+	}
+
 	// Check for skip label
 	if service.Labels != nil {
 		if skipValue, ok := service.Labels["com.dokku.orchestrate/skip"]; ok && skipValue == "true" {


### PR DESCRIPTION
These can't be restarted using our logic anyways so managing them does not make any sense.