### PR TITLE
feat: default to sh as shell executor and fix Config.Shell handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,13 +216,16 @@ services:
 - Scripts run synchronously - `docker-orchestrate` waits for completion before stopping the container
 - Interpreter selection:
   - If the script has a shebang (e.g., `#!/usr/bin/env bash`), that interpreter is used
-  - Otherwise, the container's `Config.Shell` property is used
+  - Otherwise, the container's `Config.Shell` property is used:
+    - For shell interpreters (sh, bash, dash, ash, zsh, ksh, csh, tcsh, fish): runs with `-c` flag
+    - For non-shell interpreters (python, php, etc.): runs the script directly
   - Falls back to `/bin/sh` if neither is available
 - Shebang parsing:
   - `#!/usr/bin/env bash` → `/bin/bash -c`
   - `#!/bin/sh` → `/bin/sh -c`
-  - `#!/usr/bin/python3` → `/usr/bin/python3 -c`
-  - Other interpreters are supported based on the shebang
+  - `#!/usr/bin/python3` → `/usr/bin/python3`
+  - Other shell interpreters are supported based on the shebang with `-c` flag
+  - Non-shell interpreters are used directly without `-c`
 
 **Note**: The container must have the following binaries available:
 
@@ -262,3 +265,18 @@ Both `x-healthcheck-host-command`, `x-pre-stop-host-command`, and `x-post-stop-h
 - `.ContainerShortID`: First 12 characters of the container ID.
 - `.ContainerIP`: Internal IP address of the container.
 - `.ServiceName`: Name of the service.
+
+### Host Command Shell
+
+Host commands (`x-healthcheck-host-command`, `x-pre-stop-host-command`, `x-post-stop-host-command`) are executed on the host machine using `/bin/sh` by default. To use a different interpreter, add a shebang as the first line of the command:
+
+```yaml
+services:
+  web:
+    deploy:
+      update_config:
+        x-pre-stop-host-command: |
+          #!/usr/bin/env bash
+          echo "Using bash-specific features"
+          declare -A mymap
+```

--- a/internal/scripts.go
+++ b/internal/scripts.go
@@ -39,6 +39,23 @@ func getContainerIP(ctx context.Context, client DockerClientInterface, container
 	return containerIP, nil
 }
 
+// isShellInterpreter checks if the given interpreter path is a known shell.
+// Accepts full paths (e.g., "/bin/bash") or bare names (e.g., "bash").
+func isShellInterpreter(interpreter string) bool {
+	knownShells := map[string]bool{
+		"sh":   true,
+		"bash": true,
+		"dash": true,
+		"ash":  true,
+		"zsh":  true,
+		"ksh":  true,
+		"csh":  true,
+		"tcsh": true,
+		"fish": true,
+	}
+	return knownShells[filepath.Base(interpreter)]
+}
+
 // parseShebang parses a shebang line and returns the interpreter command
 // Examples:
 //   - "#!/usr/bin/env bash" -> ["/bin/bash", "-c"]
@@ -70,11 +87,11 @@ func parseShebang(script string) []string {
 			return []string{"/bin/bash", "-c"}
 		case "sh":
 			return []string{"/bin/sh", "-c"}
-		case "python", "python3":
-			return []string{"/usr/bin/env", interpreter, "-c"}
 		default:
-			// Try to find the interpreter in common locations
-			return []string{"/usr/bin/env", interpreter, "-c"}
+			if isShellInterpreter(interpreter) {
+				return []string{"/usr/bin/env", interpreter, "-c"}
+			}
+			return []string{"/usr/bin/env", interpreter}
 		}
 	}
 
@@ -85,12 +102,10 @@ func parseShebang(script string) []string {
 	}
 
 	interpreter := parts[0]
-	// Add -c flag for shell-like interpreters
-	if strings.Contains(interpreter, "sh") || strings.Contains(interpreter, "bash") {
+	if isShellInterpreter(interpreter) {
 		return []string{interpreter, "-c"}
 	}
-	// For other interpreters, try with -c
-	return []string{interpreter, "-c"}
+	return []string{interpreter}
 }
 
 // ScriptTemplateData is the data structure for the healthcheck command template
@@ -168,7 +183,7 @@ func runHostScript(ctx context.Context, input runScriptInput) error {
 
 	command := commandBuf.String()
 	if input.Shebang == "" {
-		input.Shebang = "#!/usr/bin/env bash"
+		input.Shebang = "#!/bin/sh"
 	}
 	if !strings.HasPrefix(command, "#!") {
 		command = input.Shebang + "\n" + command
@@ -276,8 +291,16 @@ func runContainerScript(ctx context.Context, input RunContainerScriptInput) erro
 		// Use the interpreter from shebang
 		cmd = shebang
 	} else if containerJSON.Config != nil && len(containerJSON.Config.Shell) > 0 {
-		// Use Config.Shell
-		cmd = append(containerJSON.Config.Shell, "-c")
+		shell := containerJSON.Config.Shell
+		if isShellInterpreter(shell[0]) {
+			// Shell interpreter: use [path, "-c"] to avoid double -c
+			// when Config.Shell already contains "-c" (e.g., SHELL ["/bin/bash", "-c"])
+			cmd = []string{shell[0], "-c"}
+		} else {
+			// Non-shell interpreter (python, php, etc.): use as-is
+			cmd = make([]string, len(shell))
+			copy(cmd, shell)
+		}
 	} else {
 		// Fall back to sh
 		cmd = []string{"/bin/sh", "-c"}

--- a/internal/scripts_test.go
+++ b/internal/scripts_test.go
@@ -122,7 +122,7 @@ func TestRunHostScript(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		expected := "#!/usr/bin/env bash\necho 12345678901234567890 172.17.0.2 123456789012 web"
+		expected := "#!/bin/sh\necho 12345678901234567890 172.17.0.2 123456789012 web"
 		if !strings.Contains(executedCommand, expected) {
 			t.Errorf("expected command to contain %q, got %q", expected, executedCommand)
 		}
@@ -493,6 +493,40 @@ func TestGetContainerIP(t *testing.T) {
 	})
 }
 
+func TestIsShellInterpreter(t *testing.T) {
+	tests := []struct {
+		name        string
+		interpreter string
+		expected    bool
+	}{
+		{"full path bash", "/bin/bash", true},
+		{"bare bash", "bash", true},
+		{"full path sh", "/bin/sh", true},
+		{"bare sh", "sh", true},
+		{"full path dash", "/bin/dash", true},
+		{"full path ash", "/bin/ash", true},
+		{"full path zsh", "/usr/bin/zsh", true},
+		{"bare zsh", "zsh", true},
+		{"full path ksh", "/bin/ksh", true},
+		{"full path csh", "/bin/csh", true},
+		{"full path tcsh", "/bin/tcsh", true},
+		{"full path fish", "/usr/bin/fish", true},
+		{"python3", "/usr/bin/python3", false},
+		{"php", "/usr/bin/php", false},
+		{"node", "node", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isShellInterpreter(tt.interpreter)
+			if result != tt.expected {
+				t.Errorf("isShellInterpreter(%q) = %v, want %v", tt.interpreter, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestParseShebang(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -517,7 +551,7 @@ func TestParseShebang(t *testing.T) {
 		{
 			name:     "python3 shebang",
 			script:   "#!/usr/bin/python3\nprint('hello')",
-			expected: []string{"/usr/bin/python3", "-c"},
+			expected: []string{"/usr/bin/python3"},
 		},
 		{
 			name:     "direct bash path",
@@ -528,6 +562,26 @@ func TestParseShebang(t *testing.T) {
 			name:     "env sh",
 			script:   "#!/usr/bin/env sh\necho hello",
 			expected: []string{"/bin/sh", "-c"},
+		},
+		{
+			name:     "python3 direct path no -c",
+			script:   "#!/usr/bin/python3\nprint('hello')",
+			expected: []string{"/usr/bin/python3"},
+		},
+		{
+			name:     "env ruby no -c",
+			script:   "#!/usr/bin/env ruby\nputs 'hello'",
+			expected: []string{"/usr/bin/env", "ruby"},
+		},
+		{
+			name:     "env python3 no -c",
+			script:   "#!/usr/bin/env python3\nprint('hello')",
+			expected: []string{"/usr/bin/env", "python3"},
+		},
+		{
+			name:     "env zsh with -c",
+			script:   "#!/usr/bin/env zsh\necho hello",
+			expected: []string{"/usr/bin/env", "zsh", "-c"},
 		},
 	}
 
@@ -754,6 +808,130 @@ func TestRunContainerScript(t *testing.T) {
 		}
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("Config.Shell with -c already included avoids double -c", func(t *testing.T) {
+		var capturedCmd []string
+		mockClient := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						ID: id,
+					},
+					Config: &container.Config{
+						Shell: []string{"/bin/bash", "-c"},
+					},
+				}, nil
+			},
+			containerExecCreate: func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+				capturedCmd = config.Cmd
+				return container.ExecCreateResponse{ID: "exec-123"}, nil
+			},
+			containerExecStart: func(ctx context.Context, execID string, config container.ExecStartOptions) error {
+				return nil
+			},
+			containerExecAttach: func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+				reader := strings.NewReader("")
+				return types.HijackedResponse{
+					Conn:   nil,
+					Reader: bufio.NewReader(reader),
+				}, nil
+			},
+			containerExecInspect: func(ctx context.Context, execID string) (container.ExecInspect, error) {
+				return container.ExecInspect{
+					ExecID:      execID,
+					ContainerID: "test-container",
+					Running:     false,
+					ExitCode:    0,
+				}, nil
+			},
+		}
+
+		input := RunContainerScriptInput{
+			Client:      mockClient,
+			ContainerID: "test-container",
+			Script:      "echo hello",
+			ScriptPath:  "/tmp/pre-stop.sh",
+			ServiceName: "test-service",
+		}
+
+		err := runContainerScript(ctx, input)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expectedCmd := []string{"/bin/bash", "-c", "/tmp/pre-stop.sh"}
+		if len(capturedCmd) != len(expectedCmd) {
+			t.Fatalf("expected cmd %v, got %v", expectedCmd, capturedCmd)
+		}
+		for i := range capturedCmd {
+			if capturedCmd[i] != expectedCmd[i] {
+				t.Errorf("expected cmd %v, got %v", expectedCmd, capturedCmd)
+				break
+			}
+		}
+	})
+
+	t.Run("Config.Shell non-shell interpreter used as-is", func(t *testing.T) {
+		var capturedCmd []string
+		mockClient := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						ID: id,
+					},
+					Config: &container.Config{
+						Shell: []string{"/usr/bin/python3"},
+					},
+				}, nil
+			},
+			containerExecCreate: func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+				capturedCmd = config.Cmd
+				return container.ExecCreateResponse{ID: "exec-123"}, nil
+			},
+			containerExecStart: func(ctx context.Context, execID string, config container.ExecStartOptions) error {
+				return nil
+			},
+			containerExecAttach: func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+				reader := strings.NewReader("")
+				return types.HijackedResponse{
+					Conn:   nil,
+					Reader: bufio.NewReader(reader),
+				}, nil
+			},
+			containerExecInspect: func(ctx context.Context, execID string) (container.ExecInspect, error) {
+				return container.ExecInspect{
+					ExecID:      execID,
+					ContainerID: "test-container",
+					Running:     false,
+					ExitCode:    0,
+				}, nil
+			},
+		}
+
+		input := RunContainerScriptInput{
+			Client:      mockClient,
+			ContainerID: "test-container",
+			Script:      "print('hello')",
+			ScriptPath:  "/tmp/pre-stop.sh",
+			ServiceName: "test-service",
+		}
+
+		err := runContainerScript(ctx, input)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expectedCmd := []string{"/usr/bin/python3", "/tmp/pre-stop.sh"}
+		if len(capturedCmd) != len(expectedCmd) {
+			t.Fatalf("expected cmd %v, got %v", expectedCmd, capturedCmd)
+		}
+		for i := range capturedCmd {
+			if capturedCmd[i] != expectedCmd[i] {
+				t.Errorf("expected cmd %v, got %v", expectedCmd, capturedCmd)
+				break
+			}
 		}
 	})
 }


### PR DESCRIPTION
Default host script shebang to /bin/sh instead of /usr/bin/env bash for POSIX compatibility. Fix Config.Shell double -c bug where shell interpreters with -c already in Config.Shell would get a duplicate flag appended. Add isShellInterpreter allowlist to distinguish shells from non-shell interpreters like python and php.

Closes #29