### PR TITLE
Add dependabot config for github-actions, docker, and bundler

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,18 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: "bundler"
+    directory: "/.github"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add `github-actions` ecosystem to track workflow action versions
- Add `docker` ecosystem to track Dockerfile base image updates
- Add `bundler` ecosystem to track Ruby gem updates in `.github/`