### PR TITLE
Clean up non-running containers before deploy

### DIFF
--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -266,6 +266,35 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 		executor = ExecCommand
 	}
 
+	// Clean up non-running containers before deploy
+	allContainers, err := composeContainers(ctx, ComposeContainersInput{
+		Client:      input.Client,
+		ProjectName: input.ProjectName,
+		ServiceName: input.ServiceName,
+	})
+	if err != nil {
+		return fmt.Errorf("error getting all containers for cleanup: %v", err)
+	}
+
+	for _, c := range allContainers {
+		if c.State == "running" {
+			continue
+		}
+
+		containerName := c.ID
+		if len(containerName) > 12 {
+			containerName = containerName[:12]
+		}
+		if len(c.Names) > 0 {
+			containerName = strings.TrimPrefix(c.Names[0], "/")
+		}
+
+		input.Logger.LogHeader2(fmt.Sprintf("Removing non-running container %s (state=%s)", containerName, c.State))
+		if err := input.Client.ContainerRemove(ctx, c.ID, container.RemoveOptions{}); err != nil {
+			input.Logger.Warn(fmt.Sprintf("Failed to remove container %s: %v", containerName, err))
+		}
+	}
+
 	// Get current running containers
 	currentContainers, err := composeContainers(ctx, ComposeContainersInput{
 		Client:      input.Client,

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -121,6 +121,142 @@ func TestDeployServiceReplicaOverride(t *testing.T) {
 	}
 }
 
+func TestDeployServiceCleansUpNonRunningContainers(t *testing.T) {
+	tests := []struct {
+		name               string
+		allContainers      []container.Summary
+		expectedRemovals   []string
+		removeError        error
+		expectDeployError  bool
+	}{
+		{
+			name: "removes_exited_containers",
+			allContainers: []container.Summary{
+				{ID: "aaaa11111111aaaa11111111", Names: []string{"/web-1"}, State: "running"},
+				{ID: "bbbb22222222bbbb22222222", Names: []string{"/web-2"}, State: "exited"},
+				{ID: "cccc33333333cccc33333333", Names: []string{"/web-3"}, State: "exited"},
+			},
+			expectedRemovals: []string{"bbbb22222222bbbb22222222", "cccc33333333cccc33333333"},
+		},
+		{
+			name: "removes_dead_containers",
+			allContainers: []container.Summary{
+				{ID: "aaaa11111111aaaa11111111", Names: []string{"/web-1"}, State: "running"},
+				{ID: "bbbb22222222bbbb22222222", Names: []string{"/web-2"}, State: "dead"},
+			},
+			expectedRemovals: []string{"bbbb22222222bbbb22222222"},
+		},
+		{
+			name: "removes_created_containers",
+			allContainers: []container.Summary{
+				{ID: "aaaa11111111aaaa11111111", Names: []string{"/web-1"}, State: "created"},
+			},
+			expectedRemovals: []string{"aaaa11111111aaaa11111111"},
+		},
+		{
+			name: "no_non_running_containers",
+			allContainers: []container.Summary{
+				{ID: "aaaa11111111aaaa11111111", Names: []string{"/web-1"}, State: "running"},
+			},
+			expectedRemovals: []string{},
+		},
+		{
+			name:             "no_containers",
+			allContainers:    []container.Summary{},
+			expectedRemovals: []string{},
+		},
+		{
+			name: "remove_failure_continues",
+			allContainers: []container.Summary{
+				{ID: "aaaa11111111aaaa11111111", Names: []string{"/web-1"}, State: "exited"},
+			},
+			expectedRemovals: []string{"aaaa11111111aaaa11111111"},
+			removeError:      fmt.Errorf("container in use"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var removedIDs []string
+
+			firstCall := true
+			mockClient := &mockDockerClient{
+				containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+					statusFilter := options.Filters.Get("status")
+					if len(statusFilter) == 0 && firstCall {
+						// First unfiltered call: return all containers for cleanup
+						firstCall = false
+						return tt.allContainers, nil
+					}
+					// All subsequent calls (filtered to running): return empty
+					// so no rolling update or scaling happens
+					return []container.Summary{}, nil
+				},
+				containerRemove: func(ctx context.Context, id string, options container.RemoveOptions) error {
+					removedIDs = append(removedIDs, id)
+					return tt.removeError
+				},
+			}
+
+			mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+				return ExecCommandResponse{ExitCode: 0}, nil
+			}
+
+			project := &types.Project{
+				Services: types.Services{
+					"web": types.ServiceConfig{
+						Name: "web",
+					},
+				},
+			}
+
+			var buf bytes.Buffer
+			logger := &command.ZerologUi{
+				StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+				StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+				OriginalFields:    nil,
+				Ui:                nil,
+				OutputIndentField: false,
+			}
+
+			input := DeployServiceInput{
+				Client:                mockClient,
+				Executor:              mockExecutor,
+				ComposeFile:           "/tmp/docker-compose.yaml",
+				ContainerNameTemplate: "{{.ServiceName}}",
+				Logger:                logger,
+				Project:               project,
+				ProjectName:           "test",
+				ServiceName:           "web",
+			}
+
+			err := DeployService(context.Background(), input)
+
+			if tt.expectDeployError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(removedIDs) != len(tt.expectedRemovals) {
+				t.Errorf("expected %d removals, got %d. Removed: %v", len(tt.expectedRemovals), len(removedIDs), removedIDs)
+				return
+			}
+
+			for i, expectedID := range tt.expectedRemovals {
+				if removedIDs[i] != expectedID {
+					t.Errorf("expected removal[%d] = %s, got %s", i, expectedID, removedIDs[i])
+				}
+			}
+		})
+	}
+}
+
 func TestIsDatabaseService(t *testing.T) {
 	var buf bytes.Buffer
 	logger := &command.ZerologUi{

--- a/internal/mocks_test.go
+++ b/internal/mocks_test.go
@@ -13,6 +13,7 @@ type mockDockerClient struct {
 	DockerClientInterface
 	containerList        func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	containerInspect     func(ctx context.Context, id string) (container.InspectResponse, error)
+	containerRemove      func(ctx context.Context, id string, options container.RemoveOptions) error
 	containerStart       func(ctx context.Context, id string, options container.StartOptions) error
 	containerTerminate   func(ctx context.Context, id string) error
 	containerRename      func(ctx context.Context, id, name string) error
@@ -37,6 +38,13 @@ func (m *mockDockerClient) ContainerInspect(ctx context.Context, id string) (con
 		return m.containerInspect(ctx, id)
 	}
 	return container.InspectResponse{}, nil
+}
+
+func (m *mockDockerClient) ContainerRemove(ctx context.Context, id string, options container.RemoveOptions) error {
+	if m.containerRemove != nil {
+		return m.containerRemove(ctx, id, options)
+	}
+	return nil
 }
 
 func (m *mockDockerClient) ContainerStart(ctx context.Context, id string, options container.StartOptions) error {

--- a/test.bats
+++ b/test.bats
@@ -95,7 +95,7 @@ setup() {
 }
 
 teardown() {
-  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default; do
+  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup; do
     docker compose -p "$project" down --remove-orphans --timeout 5 2>/dev/null || true
   done
 
@@ -332,4 +332,62 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_equal "bash-ok" "$output"
+}
+
+@test "exited containers are cleaned up before deploy" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/exited-container-cleanup"
+
+  # Initial deploy: scale to 3 running containers via docker compose directly
+  docker compose -p bats-exited-cleanup up -d --scale web=3 --wait
+  run docker ps --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=running" -q
+  echo "initial running containers: $output"
+  assert_equal "3" "$(echo "$output" | wc -l | tr -d ' ')"
+
+  # Get container IDs for manipulation
+  container_to_stop=$(docker ps --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=running" -q | sed -n '1p')
+  container_to_kill=$(docker ps --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=running" -q | sed -n '2p')
+
+  # Stop one container gracefully (exit code 0)
+  docker stop "$container_to_stop"
+
+  # Kill another container with SIGKILL (non-zero exit code)
+  docker kill --signal=KILL "$container_to_kill"
+
+  # Verify intermediate state: 1 running, 2 exited
+  run docker ps --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=running" -q
+  echo "running after stop/kill: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+
+  run docker ps -a --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=exited" -q
+  echo "exited after stop/kill: $output"
+  assert_equal "2" "$(echo "$output" | wc -l | tr -d ' ')"
+
+  # Verify exit codes: one should be 0, one should be non-zero
+  exited_container_0=$(docker ps -a --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=exited" -q | sed -n '1p')
+  exited_container_1=$(docker ps -a --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=exited" -q | sed -n '2p')
+  exit_code_0=$(docker inspect --format '{{.State.ExitCode}}' "$exited_container_0")
+  exit_code_1=$(docker inspect --format '{{.State.ExitCode}}' "$exited_container_1")
+  echo "exit codes: $exit_code_0, $exit_code_1"
+
+  # One should be 0 and one should be non-zero (137 for SIGKILL)
+  if [[ "$exit_code_0" -eq 0 && "$exit_code_1" -ne 0 ]] || [[ "$exit_code_0" -ne 0 && "$exit_code_1" -eq 0 ]]; then
+    echo "exit code verification passed: one is 0, one is non-zero"
+  else
+    flunk "expected one exit code 0 and one non-zero, got: $exit_code_0 and $exit_code_1"
+  fi
+
+  # Redeploy with --replicas 3: should clean up exited containers and reach 3 running
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-exited-cleanup --replicas 3 web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify final state: 3 running, 0 exited
+  run docker ps --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=running" -q
+  echo "final running: $output"
+  assert_equal "3" "$(echo "$output" | wc -l | tr -d ' ')"
+
+  run docker ps -a --filter "label=com.docker.compose.project=bats-exited-cleanup" --filter "status=exited" -q
+  echo "final exited: $output"
+  assert_equal "" "$output"
 }

--- a/tests/fixtures/exited-container-cleanup/docker-compose.yaml
+++ b/tests/fixtures/exited-container-cleanup/docker-compose.yaml
@@ -1,0 +1,10 @@
+---
+services:
+  web:
+    image: nginx:latest
+    deploy:
+      replicas: 1
+      update_config:
+        order: start-first
+        delay: 0s
+        monitor: 5s


### PR DESCRIPTION
## Summary

- Remove non-running containers (exited, dead, created, etc.) for a service before querying current running containers during deploy
- Prevents exited/crashed containers from occupying docker compose "slots" that block scale-up operations
- Uses `ContainerRemove` directly since containers are already stopped; logs warnings on failure without blocking the deploy

Closes #48