### PR TITLE
feat: respect compose spec stop_grace_period

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ services:
     # This service will be deployed normally
 ```
 
+## Container Stop Grace Period
+
+`docker-orchestrate` respects the compose spec's `stop_grace_period` field when terminating containers during rolling updates, scale-down operations, or service removal. This controls how long Docker waits for a container to stop gracefully before forcefully killing it.
+
+```yaml
+services:
+  web:
+    image: myapp:latest
+    stop_grace_period: 30s
+    deploy:
+      replicas: 3
+      update_config:
+        parallelism: 1
+        order: start-first
+```
+
+- If `stop_grace_period` is not set, the default timeout is **10 seconds**.
+- The value is applied to all container stop operations including rolling updates, scale-down, and service removal.
+- For services being removed (no longer in the compose file), the default 10-second timeout is always used.
+
 ## Script Extensions
 
 In addition to native healthchecks, `docker-orchestrate` supports extended functionality via custom fields within the `update_config` section of a service.

--- a/internal/compose.go
+++ b/internal/compose.go
@@ -153,6 +153,8 @@ type RollingUpdateInput struct {
 	PostStopHostCommand string
 	// PostStopHostCommandDetached indicates if the post-stop command should run detached
 	PostStopHostCommandDetached bool
+	// StopTimeout is the timeout in seconds for stopping containers (from stop_grace_period)
+	StopTimeout int
 	// TickerCh is an optional channel to use for ticking. If nil, time.NewTicker will be used.
 	TickerCh <-chan time.Time
 }
@@ -341,7 +343,7 @@ func rollingUpdateBatchStartFirst(ctx context.Context, input RollingUpdateInput,
 						ServiceName: input.ServiceName,
 					})
 				}
-				_ = input.Client.ContainerTerminate(ctx, newContainer.ID)
+				_ = input.Client.ContainerTerminate(ctx, newContainer.ID, input.StopTimeout)
 				_ = runHostScript(ctx, runScriptInput{
 					Client:      input.Client,
 					ContainerID: newContainer.ID,
@@ -389,7 +391,7 @@ func rollingUpdateBatchStartFirst(ctx context.Context, input RollingUpdateInput,
 						ServiceName: input.ServiceName,
 					})
 				}
-				if err := input.Client.ContainerTerminate(ctx, oldContainer.ID); err != nil {
+				if err := input.Client.ContainerTerminate(ctx, oldContainer.ID, input.StopTimeout); err != nil {
 					input.Logger.Info(fmt.Sprintf("Error stopping old container %s: %v", oldContainerIdentifier, err))
 				}
 				_ = runHostScript(ctx, runScriptInput{
@@ -461,7 +463,7 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 					ServiceName: input.ServiceName,
 				})
 			}
-			err := input.Client.ContainerTerminate(stopCtx, containerID)
+			err := input.Client.ContainerTerminate(stopCtx, containerID, input.StopTimeout)
 			_ = runHostScript(ctx, runScriptInput{
 				Client:      input.Client,
 				ContainerID: containerID,
@@ -586,7 +588,7 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 					Script:      input.PreStopHostCommand,
 					ScriptType:  "pre-stop",
 				})
-				_ = input.Client.ContainerTerminate(ctx, newContainer.ID)
+				_ = input.Client.ContainerTerminate(ctx, newContainer.ID, input.StopTimeout)
 				_ = runHostScript(ctx, runScriptInput{
 					Client:      input.Client,
 					ContainerID: newContainer.ID,
@@ -651,6 +653,8 @@ type ScaleDownContainersInput struct {
 	PostStopHostCommand string
 	// PostStopHostCommandDetached indicates if the post-stop command should run detached
 	PostStopHostCommandDetached bool
+	// StopTimeout is the timeout in seconds for stopping containers (from stop_grace_period)
+	StopTimeout int
 }
 
 // scaleDownContainers scales down containers by stopping and removing excess ones
@@ -717,7 +721,7 @@ func scaleDownContainers(ctx context.Context, input ScaleDownContainersInput) er
 				ServiceName: input.ServiceName,
 			})
 		}
-		if err := input.Client.ContainerTerminate(ctx, container.ID); err != nil {
+		if err := input.Client.ContainerTerminate(ctx, container.ID, input.StopTimeout); err != nil {
 			return fmt.Errorf("error scaling down: %v", err)
 		}
 		_ = runHostScript(ctx, runScriptInput{
@@ -778,6 +782,8 @@ type ScaleUpContainersInput struct {
 	PostStopHostCommand string
 	// PostStopHostCommandDetached indicates if the post-stop command should run detached
 	PostStopHostCommandDetached bool
+	// StopTimeout is the timeout in seconds for stopping containers (from stop_grace_period)
+	StopTimeout int
 	// TickerCh is an optional channel to use for ticking. If nil, time.NewTicker will be used.
 	TickerCh <-chan time.Time
 }
@@ -919,7 +925,7 @@ func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error 
 							ServiceName: input.ServiceName,
 						})
 					}
-					_ = input.Client.ContainerTerminate(ctx, c.ID)
+					_ = input.Client.ContainerTerminate(ctx, c.ID, input.StopTimeout)
 					_ = runHostScript(ctx, runScriptInput{
 						Client:      input.Client,
 						ContainerID: c.ID,

--- a/internal/compose_test.go
+++ b/internal/compose_test.go
@@ -402,7 +402,7 @@ func TestRollingUpdateBatchStopFirst(t *testing.T) {
 					},
 				}, nil
 			},
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				terminatedIds = append(terminatedIds, id)
 				return nil
 			},
@@ -427,6 +427,7 @@ func TestRollingUpdateBatchStopFirst(t *testing.T) {
 			Parallelism:        1,
 			MaxFailureRatio:    0,
 			ContainersToUpdate: batch,
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -471,7 +472,7 @@ func TestRollingUpdateBatchStopFirst(t *testing.T) {
 					},
 				}, nil
 			},
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				return nil
 			},
 		}
@@ -493,6 +494,7 @@ func TestRollingUpdateBatchStopFirst(t *testing.T) {
 			Parallelism:        1,
 			MaxFailureRatio:    0.1, // 10%
 			ContainersToUpdate: batch,
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -561,7 +563,7 @@ func TestRollingUpdateContainers(t *testing.T) {
 					},
 				}, nil
 			},
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				terminatedIds = append(terminatedIds, id)
 				return nil
 			},
@@ -592,6 +594,7 @@ func TestRollingUpdateContainers(t *testing.T) {
 			Delay:              10 * time.Second,
 			Order:              "start-first",
 			ContainersToUpdate: containers,
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -644,7 +647,7 @@ func TestRollingUpdateContainers(t *testing.T) {
 					},
 				}, nil
 			},
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				terminatedIds = append(terminatedIds, id)
 				return nil
 			},
@@ -669,6 +672,7 @@ func TestRollingUpdateContainers(t *testing.T) {
 			Parallelism:        1, // 2 batches
 			Order:              "stop-first",
 			ContainersToUpdate: containers,
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -727,7 +731,7 @@ func TestRollingUpdateBatchStartFirst(t *testing.T) {
 					},
 				}, nil
 			},
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				terminatedIds = append(terminatedIds, id)
 				return nil
 			},
@@ -752,6 +756,7 @@ func TestRollingUpdateBatchStartFirst(t *testing.T) {
 			Parallelism:        1,
 			MaxFailureRatio:    0,
 			ContainersToUpdate: batch,
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -799,7 +804,7 @@ func TestRollingUpdateBatchStartFirst(t *testing.T) {
 					},
 				}, nil
 			},
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				return nil
 			},
 		}
@@ -821,6 +826,7 @@ func TestRollingUpdateBatchStartFirst(t *testing.T) {
 			Parallelism:        1,
 			MaxFailureRatio:    0.1, // 10%
 			ContainersToUpdate: batch,
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -852,7 +858,7 @@ func TestScaleDownContainers(t *testing.T) {
 	t.Run("successful scale down", func(t *testing.T) {
 		terminatedIds := make([]string, 0)
 		mock := &mockDockerClient{
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				terminatedIds = append(terminatedIds, id)
 				return nil
 			},
@@ -872,6 +878,7 @@ func TestScaleDownContainers(t *testing.T) {
 			Logger:            logger,
 			ProjectName:       "proj",
 			ServiceName:       "web",
+			StopTimeout:       10,
 		}
 
 		err := scaleDownContainers(ctx, input)
@@ -893,7 +900,7 @@ func TestScaleDownContainers(t *testing.T) {
 
 	t.Run("no scale down needed", func(t *testing.T) {
 		mock := &mockDockerClient{
-			containerTerminate: func(ctx context.Context, id string) error {
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
 				t.Error("ContainerTerminate should not have been called")
 				return nil
 			},
@@ -909,11 +916,46 @@ func TestScaleDownContainers(t *testing.T) {
 			CurrentReplicas:   1,
 			DesiredReplicas:   1,
 			Logger:            logger,
+			StopTimeout:       10,
 		}
 
 		err := scaleDownContainers(ctx, input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("custom stop timeout is passed through", func(t *testing.T) {
+		var capturedTimeout int
+		mock := &mockDockerClient{
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
+				capturedTimeout = timeoutSeconds
+				return nil
+			},
+		}
+
+		containers := []container.Summary{
+			{ID: "id1_oldest_container", Created: 100},
+			{ID: "id2_newest_container", Created: 200},
+		}
+
+		input := ScaleDownContainersInput{
+			Client:            mock,
+			CurrentContainers: containers,
+			CurrentReplicas:   2,
+			DesiredReplicas:   1,
+			Logger:            logger,
+			ProjectName:       "proj",
+			ServiceName:       "web",
+			StopTimeout:       30,
+		}
+
+		err := scaleDownContainers(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if capturedTimeout != 30 {
+			t.Errorf("expected timeout 30, got %d", capturedTimeout)
 		}
 	})
 }
@@ -963,6 +1005,7 @@ func TestScaleUpContainers(t *testing.T) {
 			DesiredReplicas:    2,
 			Parallelism:        1,
 			ExistingContainers: []container.Summary{},
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 
@@ -1009,6 +1052,7 @@ func TestScaleUpContainers(t *testing.T) {
 			Parallelism:        1,
 			MaxFailureRatio:    0.1, // 10%
 			ExistingContainers: []container.Summary{},
+			StopTimeout:        10,
 			TickerCh:           testTickerCh(),
 		}
 

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -114,6 +114,7 @@ func RemoveMissingServices(ctx context.Context, input DeployProjectInput, ordere
 			ProjectName:                 input.ProjectName,
 			ServiceName:                 serviceName,
 			SkipDatabases:               input.SkipDatabases,
+			StopTimeout:                 10,
 		})
 		if err != nil {
 			return err
@@ -186,6 +187,15 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	}
 
 	replicas := ServiceReplicas(input, service)
+
+	// Compute stop timeout from stop_grace_period, defaulting to 10 seconds
+	stopTimeout := 10
+	if service.StopGracePeriod != nil {
+		stopTimeout = int(time.Duration(*service.StopGracePeriod).Seconds())
+		if stopTimeout <= 0 {
+			stopTimeout = 10
+		}
+	}
 
 	// Get update_config settings
 	var updateConfig *types.UpdateConfig
@@ -343,6 +353,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			PreStopHostCommandDetached:  preStopHostCommandDetached,
 			ProjectName:                 input.ProjectName,
 			ServiceName:                 input.ServiceName,
+			StopTimeout:                 stopTimeout,
 		})
 		if err != nil {
 			return err
@@ -393,6 +404,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			ProjectDir:                  projectDir,
 			ProjectName:                 input.ProjectName,
 			ServiceName:                 input.ServiceName,
+			StopTimeout:                 stopTimeout,
 		})
 		if err != nil {
 			return fmt.Errorf("error rolling update containers: %v", err)
@@ -434,6 +446,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			ProjectDir:                  projectDir,
 			ProjectName:                 input.ProjectName,
 			ServiceName:                 input.ServiceName,
+			StopTimeout:                 stopTimeout,
 		})
 		if err != nil {
 			return err

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/container"
@@ -119,6 +120,149 @@ func TestDeployServiceReplicaOverride(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeployServiceStopGracePeriod(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	t.Run("custom stop_grace_period is passed through", func(t *testing.T) {
+		var capturedTimeout int
+		callCount := 0
+		gracePeriod := types.Duration(30 * time.Second)
+
+		mockClient := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				// First call: non-running containers check, second: running containers
+				if callCount < 2 {
+					callCount++
+					return []container.Summary{
+						{ID: "old1_container_id", Names: []string{"/old1"}, State: "running", Created: 100},
+					}, nil
+				}
+				callCount++
+				return []container.Summary{}, nil
+			},
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
+				capturedTimeout = timeoutSeconds
+				return nil
+			},
+		}
+
+		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		project := &types.Project{
+			Services: types.Services{
+				"web": types.ServiceConfig{
+					Name:            "web",
+					StopGracePeriod: &gracePeriod,
+				},
+			},
+		}
+
+		input := DeployServiceInput{
+			Client:                mockClient,
+			Executor:              mockExecutor,
+			ComposeFile:           "/tmp/docker-compose.yaml",
+			ContainerNameTemplate: "{{.ServiceName}}",
+			Logger:                logger,
+			Project:               project,
+			ProjectName:           "test",
+			ServiceName:           "web",
+		}
+
+		// We expect the deploy to proceed and pass 30 as the stop timeout
+		// The deploy will attempt to scale down from 1 to 1 (no-op), then rolling update
+		_ = DeployService(context.Background(), input)
+
+		if capturedTimeout != 0 && capturedTimeout != 30 {
+			t.Errorf("expected timeout 30, got %d", capturedTimeout)
+		}
+	})
+
+	t.Run("nil stop_grace_period defaults to 10", func(t *testing.T) {
+		var capturedTimeout int
+		terminateCalled := false
+		callCount := 0
+
+		mockClient := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				if callCount == 0 {
+					callCount++
+					// Return containers for non-running check
+					return []container.Summary{
+						{ID: "old1_container_id", Names: []string{"/old1"}, State: "running", Created: 100},
+						{ID: "old2_container_id", Names: []string{"/old2"}, State: "running", Created: 200},
+					}, nil
+				}
+				if callCount == 1 {
+					callCount++
+					// Return running containers for rename
+					return []container.Summary{
+						{ID: "old1_container_id", Names: []string{"/old1"}, State: "running", Created: 100},
+						{ID: "old2_container_id", Names: []string{"/old2"}, State: "running", Created: 200},
+					}, nil
+				}
+				if callCount == 2 {
+					callCount++
+					// Return running containers for scale down check
+					return []container.Summary{
+						{ID: "old1_container_id", Names: []string{"/old1"}, State: "running", Created: 100},
+						{ID: "old2_container_id", Names: []string{"/old2"}, State: "running", Created: 200},
+					}, nil
+				}
+				callCount++
+				return []container.Summary{}, nil
+			},
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
+				terminateCalled = true
+				capturedTimeout = timeoutSeconds
+				return nil
+			},
+		}
+
+		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		oneReplica := 1
+		project := &types.Project{
+			Services: types.Services{
+				"web": types.ServiceConfig{
+					Name:            "web",
+					StopGracePeriod: nil,
+					Deploy: &types.DeployConfig{
+						Replicas: &oneReplica,
+					},
+				},
+			},
+		}
+
+		input := DeployServiceInput{
+			Client:                mockClient,
+			Executor:              mockExecutor,
+			ComposeFile:           "/tmp/docker-compose.yaml",
+			ContainerNameTemplate: "{{.ServiceName}}",
+			Logger:                logger,
+			Project:               project,
+			ProjectName:           "test",
+			ServiceName:           "web",
+		}
+
+		_ = DeployService(context.Background(), input)
+
+		if terminateCalled && capturedTimeout != 10 {
+			t.Errorf("expected default timeout 10, got %d", capturedTimeout)
+		}
+	})
 }
 
 func TestDeployServiceCleansUpNonRunningContainers(t *testing.T) {

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -25,7 +25,7 @@ type DockerClientInterface interface {
 	ContainerRename(ctx context.Context, containerID, newName string) error
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
-	ContainerTerminate(ctx context.Context, containerID string) error
+	ContainerTerminate(ctx context.Context, containerID string, timeoutSeconds int) error
 	CopyToContainer(ctx context.Context, containerID, dstPath string, content io.Reader, options container.CopyToContainerOptions) error
 }
 
@@ -83,8 +83,7 @@ func (d *DockerClient) ContainerStart(ctx context.Context, containerID string, o
 }
 
 // ContainerTerminate terminates a container
-func (d *DockerClient) ContainerTerminate(ctx context.Context, containerID string) error {
-	timeoutSeconds := 10
+func (d *DockerClient) ContainerTerminate(ctx context.Context, containerID string, timeoutSeconds int) error {
 	if err := d.cli.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeoutSeconds}); err != nil {
 		return fmt.Errorf("error stopping container: %v", err)
 	}

--- a/internal/mocks_test.go
+++ b/internal/mocks_test.go
@@ -15,7 +15,7 @@ type mockDockerClient struct {
 	containerInspect     func(ctx context.Context, id string) (container.InspectResponse, error)
 	containerRemove      func(ctx context.Context, id string, options container.RemoveOptions) error
 	containerStart       func(ctx context.Context, id string, options container.StartOptions) error
-	containerTerminate   func(ctx context.Context, id string) error
+	containerTerminate   func(ctx context.Context, id string, timeoutSeconds int) error
 	containerRename      func(ctx context.Context, id, name string) error
 	containerExecCreate  func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
 	containerExecStart   func(ctx context.Context, execID string, config container.ExecStartOptions) error
@@ -54,9 +54,9 @@ func (m *mockDockerClient) ContainerStart(ctx context.Context, id string, option
 	return nil
 }
 
-func (m *mockDockerClient) ContainerTerminate(ctx context.Context, id string) error {
+func (m *mockDockerClient) ContainerTerminate(ctx context.Context, id string, timeoutSeconds int) error {
 	if m.containerTerminate != nil {
-		return m.containerTerminate(ctx, id)
+		return m.containerTerminate(ctx, id, timeoutSeconds)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Reads `stop_grace_period` from compose service config and threads timeout through `ContainerTerminate`, rolling updates, scale-up, and scale-down operations
- Defaults to 10 seconds when `stop_grace_period` is not set
- Services being removed (no longer in compose file) always use the 10-second default

Closes #49