### PR TITLE
Support multiple compose files via repeatable -f flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ docker orchestrate deploy --profile production --profile monitoring
 docker orchestrate deploy --profile production,monitoring
 ```
 
+Deploy with multiple compose files (layered):
+
+```bash
+docker orchestrate deploy --file docker-compose.yaml --file docker-compose.prod.yaml
+docker orchestrate deploy -f docker-compose.yaml -f docker-compose.prod.yaml
+```
+
 Deploy while skipping database services:
 
 ```bash
@@ -57,7 +64,7 @@ docker orchestrate deploy web --skip-databases
 
 ### Flags
 
-- `-f, --file`: Path to the Compose configuration file (defaults to `docker-compose.yaml` or `docker-compose.yml`).
+- `-f, --file`: Path to a Compose configuration file. Can be specified multiple times to merge files (defaults to `docker-compose.yaml` or `docker-compose.yml`).
 - `-p, --project-name`: Specify an alternate project name (defaults to the directory name).
 - `--project-directory`: Specify an alternate working directory.
 - `--container-name-template`: Go template for container names. Available variables: `.ProjectName`, `.ServiceName`, `.InstanceID`. Default: `{{.ProjectName}}-{{.ServiceName}}-{{.InstanceID}}`.

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dokku/docker-orchestrate/internal"
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -16,7 +17,7 @@ type DeployCommand struct {
 	command.Meta
 
 	containerNameTemplate string
-	file                  string
+	files                 []string
 	profiles              []string
 	projectDirectory      string
 	projectName           string
@@ -68,7 +69,7 @@ func (c *DeployCommand) FlagSet() *flag.FlagSet {
 	f.IntVar(&c.replicas, "replicas", 0, "the number of replicas to deploy")
 	f.StringSliceVar(&c.profiles, "profile", []string{}, "one or more profiles to enable")
 	f.StringVar(&c.containerNameTemplate, "container-name-template", "{{.ProjectName}}-{{.ServiceName}}-{{.InstanceID}}", "the template for the container name")
-	f.StringVar(&c.file, "file", "", "the path to the Compose file")
+	f.StringSliceVar(&c.files, "file", []string{}, "one or more paths to Compose files")
 	f.StringVar(&c.projectDirectory, "project-directory", "", "the path to the project directory")
 	f.StringVar(&c.projectName, "project-name", "", "the name of the project")
 	f.BoolVar(&c.skipDatabases, "skip-databases", false, "whether to skip deploying databases")
@@ -106,24 +107,25 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
-	if c.file == "" {
-		c.file, err = internal.ComposeFile()
-		if err != nil {
-			c.Ui.Error(err.Error())
+	if len(c.files) == 0 {
+		detectedFile, detectErr := internal.ComposeFile()
+		if detectErr != nil {
+			c.Ui.Error(detectErr.Error())
 			return 1
 		}
+		c.files = []string{detectedFile}
 	}
 
 	if c.projectDirectory == "" {
-		c.projectDirectory = filepath.Dir(c.file)
+		c.projectDirectory = filepath.Dir(c.files[0])
 	}
 
 	if c.projectName == "" {
-		c.projectName = filepath.Base(filepath.Dir(c.file))
+		c.projectName = filepath.Base(filepath.Dir(c.files[0]))
 	}
 
 	ctx := context.Background()
-	project, err := internal.ComposeProject(ctx, c.projectName, c.file, c.profiles)
+	project, err := internal.ComposeProject(ctx, c.projectName, c.files, c.profiles)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -148,10 +150,10 @@ func (c *DeployCommand) Run(args []string) int {
 			return 1
 		}
 
-		logger.LogHeader1(fmt.Sprintf("Deploying entire project from %s", c.file))
+		logger.LogHeader1(fmt.Sprintf("Deploying entire project from %s", strings.Join(c.files, ", ")))
 		err = internal.DeployProject(ctx, internal.DeployProjectInput{
 			Client:                client,
-			ComposeFile:           c.file,
+			ComposeFiles:          c.files,
 			ContainerNameTemplate: c.containerNameTemplate,
 			Logger:                logger,
 			Project:               project,
@@ -169,7 +171,7 @@ func (c *DeployCommand) Run(args []string) int {
 	logger.LogHeader2(fmt.Sprintf("Deploying service %s", serviceName))
 	err = internal.DeployService(ctx, internal.DeployServiceInput{
 		Client:                client,
-		ComposeFile:           c.file,
+		ComposeFiles:          c.files,
 		ContainerNameTemplate: c.containerNameTemplate,
 		Logger:                logger,
 		Project:               project,

--- a/internal/compose.go
+++ b/internal/compose.go
@@ -46,9 +46,9 @@ func ComposeFile() (string, error) {
 	return "", errors.New("no compose file found")
 }
 
-// ComposeProject reads the compose file specified by the filename
+// ComposeProject reads the compose files specified by the filenames
 // and returns the compose types.Project
-func ComposeProject(ctx context.Context, projectName string, filename string, profiles []string) (*types.Project, error) {
+func ComposeProject(ctx context.Context, projectName string, filenames []string, profiles []string) (*types.Project, error) {
 	opts := []cli.ProjectOptionsFn{
 		cli.WithOsEnv,
 		cli.WithDotEnv,
@@ -56,7 +56,7 @@ func ComposeProject(ctx context.Context, projectName string, filename string, pr
 		cli.WithName(projectName),
 	}
 
-	options, err := cli.NewProjectOptions([]string{filename}, opts...)
+	options, err := cli.NewProjectOptions(filenames, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating project options: %v", err)
 	}
@@ -67,6 +67,16 @@ func ComposeProject(ctx context.Context, projectName string, filename string, pr
 	}
 
 	return project, nil
+}
+
+// composeFileArgs returns the command-line arguments for specifying
+// one or more compose files to docker compose (e.g., ["-f", "a.yml", "-f", "b.yml"]).
+func composeFileArgs(files []string) []string {
+	args := make([]string, 0, len(files)*2)
+	for _, f := range files {
+		args = append(args, "-f", f)
+	}
+	return args
 }
 
 // ComposeContainersInput is the input for the ComposeContainers function
@@ -109,8 +119,8 @@ func composeContainers(ctx context.Context, input ComposeContainersInput) ([]con
 type RollingUpdateInput struct {
 	// Client is the Docker client to use. If nil, a new one will be created.
 	Client DockerClientInterface
-	// ComposeFile is the path to the compose file
-	ComposeFile string
+	// ComposeFiles is the list of paths to the compose files
+	ComposeFiles []string
 	// ContainersToUpdate is the list of containers to update
 	ContainersToUpdate []container.Summary
 	// CurrentReplicas is the current number of replicas
@@ -230,19 +240,14 @@ func rollingUpdateBatchStartFirst(ctx context.Context, input RollingUpdateInput,
 
 	// Start new containers
 	newScale := len(currentContainers) + len(batch)
+	args := []string{"compose"}
+	args = append(args, composeFileArgs(input.ComposeFiles)...)
+	args = append(args, "-p", input.ProjectName, "up", "--detach",
+		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, newScale),
+		"--no-deps", "--no-recreate", input.ServiceName)
 	_, err = input.Executor(ctx, ExecCommandInput{
-		Command: "docker",
-		Args: []string{
-			"compose",
-			"-f", input.ComposeFile,
-			"-p", input.ProjectName,
-			"up",
-			"--detach",
-			"--scale", fmt.Sprintf("%s=%d", input.ServiceName, newScale),
-			"--no-deps",
-			"--no-recreate",
-			input.ServiceName,
-		},
+		Command:          "docker",
+		Args:             args,
 		WorkingDirectory: input.ProjectDir,
 	})
 	if err != nil {
@@ -518,19 +523,14 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 
 	// Start new containers
 	targetScale := len(currentContainers) + len(batch)
+	args := []string{"compose"}
+	args = append(args, composeFileArgs(input.ComposeFiles)...)
+	args = append(args, "-p", input.ProjectName, "up", "--detach",
+		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, targetScale),
+		"--no-deps", "--no-recreate", input.ServiceName)
 	_, err = input.Executor(ctx, ExecCommandInput{
-		Command: "docker",
-		Args: []string{
-			"compose",
-			"-f", input.ComposeFile,
-			"-p", input.ProjectName,
-			"up",
-			"--detach",
-			"--scale", fmt.Sprintf("%s=%d", input.ServiceName, targetScale),
-			"--no-deps",
-			"--no-recreate",
-			input.ServiceName,
-		},
+		Command:          "docker",
+		Args:             args,
 		WorkingDirectory: input.ProjectDir,
 	})
 	if err != nil {
@@ -648,8 +648,8 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 type ScaleDownContainersInput struct {
 	// Client is the Docker client to use. If nil, a new one will be created.
 	Client DockerClientInterface
-	// ComposeFile is the path to the compose file
-	ComposeFile string
+	// ComposeFiles is the list of paths to the compose files
+	ComposeFiles []string
 	// CurrentContainers is the current list of containers
 	CurrentContainers []container.Summary
 	// CurrentReplicas is the current number of containers
@@ -774,8 +774,8 @@ func scaleDownContainers(ctx context.Context, input ScaleDownContainersInput) er
 type ScaleUpContainersInput struct {
 	// Client is the Docker client to use. If nil, a new one will be created.
 	Client DockerClientInterface
-	// ComposeFile is the path to the compose file
-	ComposeFile string
+	// ComposeFiles is the list of paths to the compose files
+	ComposeFiles []string
 	// CurrentReplicas is the current number of containers
 	CurrentReplicas int
 	// Delay is the delay between batches
@@ -834,16 +834,14 @@ func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error 
 	}
 
 	// Create all containers at once
+	args := []string{"compose"}
+	args = append(args, composeFileArgs(input.ComposeFiles)...)
+	args = append(args, "-p", input.ProjectName, "create",
+		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, input.DesiredReplicas),
+		input.ServiceName)
 	_, err := executor(ctx, ExecCommandInput{
-		Command: "docker",
-		Args: []string{
-			"compose",
-			"-f", input.ComposeFile,
-			"-p", input.ProjectName,
-			"create",
-			"--scale", fmt.Sprintf("%s=%d", input.ServiceName, input.DesiredReplicas),
-			input.ServiceName,
-		},
+		Command:          "docker",
+		Args:             args,
 		WorkingDirectory: input.ProjectDir,
 	})
 	if err != nil {

--- a/internal/compose_test.go
+++ b/internal/compose_test.go
@@ -160,6 +160,116 @@ func TestComposeFile(t *testing.T) {
 	})
 }
 
+func TestComposeFileArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    []string
+		expected []string
+	}{
+		{
+			name:     "single file",
+			files:    []string{"docker-compose.yaml"},
+			expected: []string{"-f", "docker-compose.yaml"},
+		},
+		{
+			name:     "multiple files",
+			files:    []string{"docker-compose.yaml", "docker-compose.override.yaml"},
+			expected: []string{"-f", "docker-compose.yaml", "-f", "docker-compose.override.yaml"},
+		},
+		{
+			name:     "empty",
+			files:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := composeFileArgs(tt.files)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected %d args, got %d: %v", len(tt.expected), len(result), result)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("arg[%d]: expected %q, got %q", i, tt.expected[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestComposeProjectMultipleFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	baseContent := `services:
+  web:
+    image: nginx:latest
+`
+	overrideContent := `services:
+  web:
+    environment:
+      OVERRIDE_APPLIED: "true"
+`
+
+	basePath := tempDir + "/docker-compose.yaml"
+	overridePath := tempDir + "/docker-compose.override.yaml"
+
+	if err := os.WriteFile(basePath, []byte(baseContent), 0644); err != nil {
+		t.Fatalf("failed to write base file: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(overrideContent), 0644); err != nil {
+		t.Fatalf("failed to write override file: %v", err)
+	}
+
+	ctx := context.Background()
+
+	t.Run("single file", func(t *testing.T) {
+		project, err := ComposeProject(ctx, "test", []string{basePath}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		service, err := project.GetService("web")
+		if err != nil {
+			t.Fatalf("service 'web' not found: %v", err)
+		}
+
+		if service.Image != "nginx:latest" {
+			t.Errorf("expected image 'nginx:latest', got %q", service.Image)
+		}
+
+		if service.Environment != nil {
+			if _, ok := service.Environment["OVERRIDE_APPLIED"]; ok {
+				t.Error("did not expect OVERRIDE_APPLIED in single-file mode")
+			}
+		}
+	})
+
+	t.Run("multiple files merged", func(t *testing.T) {
+		project, err := ComposeProject(ctx, "test", []string{basePath, overridePath}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		service, err := project.GetService("web")
+		if err != nil {
+			t.Fatalf("service 'web' not found: %v", err)
+		}
+
+		if service.Image != "nginx:latest" {
+			t.Errorf("expected image 'nginx:latest', got %q", service.Image)
+		}
+
+		val, ok := service.Environment["OVERRIDE_APPLIED"]
+		if !ok {
+			t.Fatal("expected OVERRIDE_APPLIED in environment")
+		}
+		if val == nil || *val != "true" {
+			t.Errorf("expected OVERRIDE_APPLIED='true', got %v", val)
+		}
+	})
+}
+
 func TestRenameContainersToConvention(t *testing.T) {
 	ctx := context.Background()
 	containers := []container.Summary{

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -19,8 +19,8 @@ import (
 type DeployProjectInput struct {
 	// Client is the Docker client to use
 	Client DockerClientInterface
-	// ComposeFile is the path to the compose file
-	ComposeFile string
+	// ComposeFiles is the list of paths to the compose files
+	ComposeFiles []string
 	// ContainerNameTemplate is the Go template for container names
 	ContainerNameTemplate string
 	// Executor is the command executor to use
@@ -46,7 +46,7 @@ func DeployProject(ctx context.Context, input DeployProjectInput) error {
 		input.Logger.LogHeader2(fmt.Sprintf("Deploying service %s", serviceName))
 		err = DeployService(ctx, DeployServiceInput{
 			Client:                input.Client,
-			ComposeFile:           input.ComposeFile,
+			ComposeFiles:          input.ComposeFiles,
 			ContainerNameTemplate: input.ContainerNameTemplate,
 			Executor:              input.Executor,
 			Logger:                input.Logger,
@@ -100,7 +100,7 @@ func RemoveMissingServices(ctx context.Context, input DeployProjectInput, ordere
 		input.Logger.LogHeader2(fmt.Sprintf("Removing service %s", serviceName))
 		err = scaleDownContainers(ctx, ScaleDownContainersInput{
 			Client:                      input.Client,
-			ComposeFile:                 input.ComposeFile,
+			ComposeFiles:                input.ComposeFiles,
 			CurrentContainers:           currentContainers,
 			CurrentReplicas:             len(currentContainers),
 			DesiredReplicas:             0,
@@ -129,8 +129,8 @@ func RemoveMissingServices(ctx context.Context, input DeployProjectInput, ordere
 type DeployServiceInput struct {
 	// Client is the Docker client to use
 	Client DockerClientInterface
-	// ComposeFile is the path to the compose file
-	ComposeFile string
+	// ComposeFiles is the list of paths to the compose files
+	ComposeFiles []string
 	// ContainerNameTemplate is the Go template for container names
 	ContainerNameTemplate string
 	// Executor is the command executor to use
@@ -151,7 +151,7 @@ type DeployServiceInput struct {
 
 // DeployService deploys a single service
 func DeployService(ctx context.Context, input DeployServiceInput) error {
-	if input.ComposeFile == "" {
+	if len(input.ComposeFiles) == 0 {
 		return fmt.Errorf("compose file is required")
 	}
 
@@ -273,7 +273,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	preStopHooks := service.PreStop
 	postStartHooks := service.PostStart
 
-	projectDir := filepath.Dir(input.ComposeFile)
+	projectDir := filepath.Dir(input.ComposeFiles[0])
 
 	executor := input.Executor
 	if executor == nil {
@@ -344,7 +344,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	if len(currentContainers) > replicas {
 		err := scaleDownContainers(ctx, ScaleDownContainersInput{
 			Client:                      input.Client,
-			ComposeFile:                 input.ComposeFile,
+			ComposeFiles:                input.ComposeFiles,
 			CurrentContainers:           currentContainers,
 			CurrentReplicas:             len(currentContainers),
 			DesiredReplicas:             replicas,
@@ -388,7 +388,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	if len(containersToUpdate) > 0 {
 		rollingUpdateOutput, err = rollingUpdateContainers(ctx, RollingUpdateInput{
 			Client:                      input.Client,
-			ComposeFile:                 input.ComposeFile,
+			ComposeFiles:                input.ComposeFiles,
 			ContainersToUpdate:          containersToUpdate,
 			CurrentReplicas:             len(containersToUpdate),
 			Delay:                       delay,
@@ -432,7 +432,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	if len(updatedContainers) < replicas {
 		err := scaleUpContainers(ctx, ScaleUpContainersInput{
 			Client:                      input.Client,
-			ComposeFile:                 input.ComposeFile,
+			ComposeFiles:                input.ComposeFiles,
 			CurrentReplicas:             len(updatedContainers),
 			Delay:                       delay,
 			DesiredReplicas:             replicas,

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -95,7 +95,7 @@ func TestDeployServiceReplicaOverride(t *testing.T) {
 			input := DeployServiceInput{
 				Client:                mockClient,
 				Executor:              mockExecutor,
-				ComposeFile:           "/tmp/docker-compose.yaml",
+				ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
 				ContainerNameTemplate: "{{.ServiceName}}",
 				Logger:                logger,
 				Project:               project,
@@ -173,7 +173,7 @@ func TestDeployServiceStopGracePeriod(t *testing.T) {
 		input := DeployServiceInput{
 			Client:                mockClient,
 			Executor:              mockExecutor,
-			ComposeFile:           "/tmp/docker-compose.yaml",
+			ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
 			ContainerNameTemplate: "{{.ServiceName}}",
 			Logger:                logger,
 			Project:               project,
@@ -251,7 +251,7 @@ func TestDeployServiceStopGracePeriod(t *testing.T) {
 		input := DeployServiceInput{
 			Client:                mockClient,
 			Executor:              mockExecutor,
-			ComposeFile:           "/tmp/docker-compose.yaml",
+			ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
 			ContainerNameTemplate: "{{.ServiceName}}",
 			Logger:                logger,
 			Project:               project,
@@ -368,7 +368,7 @@ func TestDeployServiceCleansUpNonRunningContainers(t *testing.T) {
 			input := DeployServiceInput{
 				Client:                mockClient,
 				Executor:              mockExecutor,
-				ComposeFile:           "/tmp/docker-compose.yaml",
+				ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
 				ContainerNameTemplate: "{{.ServiceName}}",
 				Logger:                logger,
 				Project:               project,
@@ -1340,7 +1340,7 @@ func TestDeployServicePreStopHooks(t *testing.T) {
 		input := DeployServiceInput{
 			Client:                mockClient,
 			Executor:              mockExecutor,
-			ComposeFile:           "/tmp/docker-compose.yaml",
+			ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
 			ContainerNameTemplate: "{{.ServiceName}}",
 			Logger:                logger,
 			Project:               project,
@@ -1446,7 +1446,7 @@ func TestDeployServicePostStartHooks(t *testing.T) {
 		input := DeployServiceInput{
 			Client:                mockClient,
 			Executor:              mockExecutor,
-			ComposeFile:           "/tmp/docker-compose.yaml",
+			ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
 			ContainerNameTemplate: "{{.ServiceName}}",
 			Logger:                logger,
 			Project:               project,
@@ -1468,6 +1468,89 @@ func TestDeployServicePostStartHooks(t *testing.T) {
 			t.Errorf("expected hook command 'sh -c echo started' to be executed, got %v", hookCmds)
 		}
 	})
+}
+
+func TestDeployServiceEmptyComposeFiles(t *testing.T) {
+	err := DeployService(context.Background(), DeployServiceInput{
+		ComposeFiles: []string{},
+		ProjectName:  "test",
+		ServiceName:  "web",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty ComposeFiles, got nil")
+	}
+	if !strings.Contains(err.Error(), "compose file is required") {
+		t.Errorf("expected 'compose file is required' error, got: %v", err)
+	}
+}
+
+func TestDeployServiceMultipleComposeFiles(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx:latest",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml", "/tmp/docker-compose.override.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that executed docker compose commands contain both -f flags
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		foundFirst := false
+		foundSecond := false
+		for i, arg := range args {
+			if arg == "-f" && i+1 < len(args) {
+				if args[i+1] == "/tmp/docker-compose.yaml" {
+					foundFirst = true
+				}
+				if args[i+1] == "/tmp/docker-compose.override.yaml" {
+					foundSecond = true
+				}
+			}
+		}
+		if !foundFirst || !foundSecond {
+			t.Errorf("expected both -f flags in compose command, got args: %v", args)
+		}
+	}
 }
 
 func intPtr(i int) *int {

--- a/test.bats
+++ b/test.bats
@@ -97,7 +97,7 @@ setup() {
 }
 
 teardown() {
-  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks; do
+  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file; do
     docker compose -p "$project" down --remove-orphans --timeout 5 2>/dev/null || true
   done
 
@@ -491,4 +491,22 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_equal "interpolated-ok" "$output"
+}
+
+@test "multiple compose files via repeated --file flag" {
+  run "$DOCKER_ORCHESTRATE" deploy \
+    --file "${BATS_TEST_DIRNAME}/tests/fixtures/multiple-files/docker-compose.yaml" \
+    --file "${BATS_TEST_DIRNAME}/tests/fixtures/multiple-files/docker-compose.override.yaml" \
+    --project-name bats-multi-file web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify the override was applied by checking the env var on the running container
+  container_id=$(docker ps --filter "label=com.docker.compose.project=bats-multi-file" --filter "status=running" -q | head -1)
+  run docker exec "$container_id" printenv OVERRIDE_APPLIED
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_equal "true" "$output"
 }

--- a/tests/fixtures/multiple-files/docker-compose.override.yaml
+++ b/tests/fixtures/multiple-files/docker-compose.override.yaml
@@ -1,0 +1,4 @@
+services:
+  web:
+    environment:
+      OVERRIDE_APPLIED: "true"

--- a/tests/fixtures/multiple-files/docker-compose.yaml
+++ b/tests/fixtures/multiple-files/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  web:
+    image: nginx:latest
+    labels:
+      test.base: "true"


### PR DESCRIPTION
## Summary

- Change `--file` from a single string flag to a repeatable string slice, allowing users to layer compose files (e.g., `-f base.yml -f prod.yml`)
- Convert `ComposeFile string` → `ComposeFiles []string` across all input structs
- Update `ComposeProject()` to accept `[]string` filenames (compose-go already supports this)
- Add `composeFileArgs()` helper for DRY `-f` flag construction in docker compose subprocess calls
- Add unit tests for multi-file merging, flag construction, validation, and multi-file deploy
- Add bats integration test with base + override fixture verifying environment variable merge

Closes #52