### PR TITLE
feat: respect pull_policy and add --pull CLI override

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ docker orchestrate deploy --env-file .env.production
 docker orchestrate deploy --env-file .env.production --env-file .env.secrets
 ```
 
+Deploy with a specific image pull policy:
+
+```bash
+docker orchestrate deploy --pull always
+docker orchestrate deploy --pull missing web
+```
+
 Deploy while skipping database services:
 
 ```bash
@@ -77,6 +84,7 @@ docker orchestrate deploy web --skip-databases
 - `--project-directory`: Specify an alternate working directory.
 - `--container-name-template`: Go template for container names. Available variables: `.ProjectName`, `.ServiceName`, `.InstanceID`. Default: `{{.ProjectName}}-{{.ServiceName}}-{{.InstanceID}}`.
 - `--profile`: One or more profiles to enable. Can be specified multiple times or as a comma-separated list.
+- `--pull`: Set the image pull policy. Valid values: `always` (always pull), `missing` (pull only if not present locally), `never` (never pull). Overrides the compose file's `pull_policy` when specified. Defaults to `missing` if neither the flag nor `pull_policy` is set.
 - `--replicas`: Override the number of replicas for a specific service. This flag requires a `service-name` argument.
 - `--skip-databases`: Skip deploying database services - as detected by image - when deploying the entire project or a specific service.
 
@@ -183,6 +191,37 @@ services:
 - If `stop_grace_period` is not set, the default timeout is **10 seconds**.
 - The value is applied to all container stop operations including rolling updates, scale-down, and service removal.
 - For services being removed (no longer in the compose file), the default 10-second timeout is always used.
+
+## Image Pull Policy
+
+`docker-orchestrate` respects the compose spec's `pull_policy` field and provides a `--pull` CLI flag to override it.
+
+```yaml
+services:
+  web:
+    image: myapp:latest
+    pull_policy: always
+```
+
+### Pull Policy Resolution
+
+The effective pull policy is determined as follows:
+
+1. If the `--pull` CLI flag is specified, it takes precedence over the compose file's `pull_policy`
+2. Otherwise, the service's `pull_policy` from the compose file is used
+3. If neither is set, the default is `missing`
+
+### Supported Values
+
+| Value | Behavior |
+|-------|----------|
+| `always` | Always pull the image before deploying. A `docker compose pull` is run before the rolling update to download the image once upfront. |
+| `missing` | Only pull the image if it is not already present locally. This is the default behavior. |
+| `never` | Never pull the image. The image must already be available locally. |
+
+The compose spec value `if_not_present` is treated as `missing`.
+
+The compose spec values `build` and `refresh` are not supported and will produce an error.
 
 ## Script Extensions
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/dotenv"
@@ -23,6 +24,7 @@ type DeployCommand struct {
 	profiles              []string
 	projectDirectory      string
 	projectName           string
+	pull                  string
 	replicas              int
 	skipDatabases         bool
 }
@@ -75,6 +77,7 @@ func (c *DeployCommand) FlagSet() *flag.FlagSet {
 	f.StringSliceVar(&c.files, "file", []string{}, "one or more paths to Compose files")
 	f.StringVar(&c.projectDirectory, "project-directory", "", "the path to the project directory")
 	f.StringVar(&c.projectName, "project-name", "", "the name of the project")
+	f.StringVar(&c.pull, "pull", "", "pull image policy (always, missing, never)")
 	f.BoolVar(&c.skipDatabases, "skip-databases", false, "whether to skip deploying databases")
 	return f
 }
@@ -89,6 +92,7 @@ func (c *DeployCommand) AutocompleteFlags() complete.Flags {
 			"--profiles":                complete.PredictAnything,
 			"--project-directory":       complete.PredictDirs("*"),
 			"--project-name":            complete.PredictAnything,
+			"--pull":                    complete.PredictSet("always", "missing", "never"),
 			"--replicas":                complete.PredictAnything,
 			"--skip-databases":          complete.PredictNothing,
 		},
@@ -108,6 +112,12 @@ func (c *DeployCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(err.Error())
 		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	validPullPolicies := []string{"always", "missing", "never"}
+	if c.pull != "" && !slices.Contains(validPullPolicies, c.pull) {
+		c.Ui.Error(fmt.Sprintf("invalid --pull value %q: must be one of: always, missing, never", c.pull))
 		return 1
 	}
 
@@ -174,6 +184,7 @@ func (c *DeployCommand) Run(args []string) int {
 			Logger:                logger,
 			Project:               project,
 			ProjectName:           c.projectName,
+			PullPolicy:            c.pull,
 			SkipDatabases:         c.skipDatabases,
 		})
 		if err != nil {
@@ -194,6 +205,7 @@ func (c *DeployCommand) Run(args []string) int {
 		Logger:                logger,
 		Project:               project,
 		ProjectName:           c.projectName,
+		PullPolicy:            c.pull,
 		Replicas:              c.replicas,
 		ServiceName:           serviceName,
 		SkipDatabases:         c.skipDatabases,

--- a/internal/compose.go
+++ b/internal/compose.go
@@ -164,6 +164,8 @@ type RollingUpdateInput struct {
 	ProjectDir string
 	// ProjectName is the name of the project
 	ProjectName string
+	// PullPolicy is the pull policy to pass to docker compose (always, missing, never)
+	PullPolicy string
 	// ServiceName is the name of the service
 	ServiceName string
 	// Sleeper is the function to use for sleeping. If nil, time.Sleep will be used.
@@ -259,6 +261,7 @@ func rollingUpdateBatchStartFirst(ctx context.Context, input RollingUpdateInput,
 	args = append(args, composeFileArgs(input.ComposeFiles)...)
 	args = append(args, envFileArgs(input.EnvFiles)...)
 	args = append(args, "-p", input.ProjectName, "up", "--detach",
+		"--pull", input.PullPolicy,
 		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, newScale),
 		"--no-deps", "--no-recreate", input.ServiceName)
 	_, err = input.Executor(ctx, ExecCommandInput{
@@ -552,6 +555,7 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 	args = append(args, composeFileArgs(input.ComposeFiles)...)
 	args = append(args, envFileArgs(input.EnvFiles)...)
 	args = append(args, "-p", input.ProjectName, "up", "--detach",
+		"--pull", input.PullPolicy,
 		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, targetScale),
 		"--no-deps", "--no-recreate", input.ServiceName)
 	_, err = input.Executor(ctx, ExecCommandInput{
@@ -843,6 +847,8 @@ type ScaleUpContainersInput struct {
 	ProjectDir string
 	// ProjectName is the name of the project
 	ProjectName string
+	// PullPolicy is the pull policy to pass to docker compose (always, missing, never)
+	PullPolicy string
 	// ServiceName is the name of the service
 	ServiceName string
 	// PreStopHostCommand is the command to run before stopping a container (on host)
@@ -877,6 +883,7 @@ func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error 
 	args = append(args, composeFileArgs(input.ComposeFiles)...)
 	args = append(args, envFileArgs(input.EnvFiles)...)
 	args = append(args, "-p", input.ProjectName, "create",
+		"--pull", input.PullPolicy,
 		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, input.DesiredReplicas),
 		input.ServiceName)
 	_, err := executor(ctx, ExecCommandInput{

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -36,6 +36,8 @@ type DeployProjectInput struct {
 	Project *types.Project
 	// ProjectName is the name of the project
 	ProjectName string
+	// PullPolicy is the pull policy override from the CLI flag (always, missing, never)
+	PullPolicy string
 	// SkipDatabases is whether to skip deploying databases
 	SkipDatabases bool
 }
@@ -59,6 +61,7 @@ func DeployProject(ctx context.Context, input DeployProjectInput) error {
 			Logger:                input.Logger,
 			Project:               input.Project,
 			ProjectName:           input.ProjectName,
+			PullPolicy:            input.PullPolicy,
 			ServiceName:           serviceName,
 			SkipDatabases:         input.SkipDatabases,
 		})
@@ -154,6 +157,8 @@ type DeployServiceInput struct {
 	Project *types.Project
 	// ProjectName is the name of the project
 	ProjectName string
+	// PullPolicy is the pull policy override from the CLI flag (always, missing, never)
+	PullPolicy string
 	// Replicas is the number of replicas to deploy
 	Replicas int
 	// ServiceName is the name of the service
@@ -198,6 +203,11 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	})
 	if skipService {
 		return nil
+	}
+
+	pullPolicy, err := ResolvePullPolicy(input.PullPolicy, service)
+	if err != nil {
+		return err
 	}
 
 	replicas := ServiceReplicas(input, service)
@@ -342,6 +352,23 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 		}
 	}
 
+	// Pre-pull image when pull policy is "always" to avoid redundant pulls during each batch
+	if pullPolicy == "always" {
+		input.Logger.Info(fmt.Sprintf("Pulling image for service %s", input.ServiceName))
+		pullArgs := []string{"compose"}
+		pullArgs = append(pullArgs, composeFileArgs(input.ComposeFiles)...)
+		pullArgs = append(pullArgs, envFileArgs(input.EnvFiles)...)
+		pullArgs = append(pullArgs, "-p", input.ProjectName, "pull", input.ServiceName)
+		_, err = executor(ctx, ExecCommandInput{
+			Command:          "docker",
+			Args:             pullArgs,
+			WorkingDirectory: projectDir,
+		})
+		if err != nil {
+			return fmt.Errorf("error pulling image for service %s: %v", input.ServiceName, err)
+		}
+	}
+
 	// Get current running containers
 	currentContainers, err := composeContainers(ctx, ComposeContainersInput{
 		Client:      input.Client,
@@ -426,6 +453,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			PreStopHostCommandDetached:  preStopHostCommandDetached,
 			ProjectDir:                  projectDir,
 			ProjectName:                 input.ProjectName,
+			PullPolicy:                  pullPolicy,
 			ServiceName:                 input.ServiceName,
 			StopTimeout:                 stopTimeout,
 		})
@@ -470,6 +498,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			PreStopHooks:                preStopHooks,
 			PreStopHostCommand:          preStopHostCommand,
 			PreStopHostCommandDetached:  preStopHostCommandDetached,
+			PullPolicy:                  pullPolicy,
 			ProjectDir:                  projectDir,
 			ProjectName:                 input.ProjectName,
 			ServiceName:                 input.ServiceName,
@@ -676,6 +705,35 @@ func isDatabaseService(serviceImage string, logger *command.ZerologUi) bool {
 	}
 
 	return false
+}
+
+// ResolvePullPolicy resolves the effective pull policy from the CLI flag and compose spec.
+// CLI flag takes precedence. If neither is set, defaults to "missing".
+// Compose spec "if_not_present" is mapped to "missing".
+// Compose spec "build" and "refresh" are not supported and return an error.
+func ResolvePullPolicy(cliPullPolicy string, service *types.ServiceConfig) (string, error) {
+	if cliPullPolicy != "" {
+		return cliPullPolicy, nil
+	}
+
+	switch service.PullPolicy {
+	case "":
+		return "missing", nil
+	case types.PullPolicyAlways:
+		return "always", nil
+	case types.PullPolicyNever:
+		return "never", nil
+	case types.PullPolicyMissing:
+		return "missing", nil
+	case types.PullPolicyIfNotPresent:
+		return "missing", nil
+	case types.PullPolicyBuild:
+		return "", fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
+	case types.PullPolicyRefresh:
+		return "", fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
+	default:
+		return "", fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
+	}
 }
 
 // ServiceReplicas returns the number of containers that should be running

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -1719,6 +1719,538 @@ func TestDeployServiceEnvVarsPassedToHooks(t *testing.T) {
 	}
 }
 
+func TestResolvePullPolicy(t *testing.T) {
+	tests := []struct {
+		name           string
+		cliPullPolicy  string
+		servicePull    string
+		expectedPolicy string
+		expectError    bool
+		errorContains  string
+	}{
+		// CLI override cases
+		{
+			name:           "cli_always_overrides_compose",
+			cliPullPolicy:  "always",
+			servicePull:    "never",
+			expectedPolicy: "always",
+		},
+		{
+			name:           "cli_missing_overrides_compose",
+			cliPullPolicy:  "missing",
+			servicePull:    "always",
+			expectedPolicy: "missing",
+		},
+		{
+			name:           "cli_never_overrides_compose",
+			cliPullPolicy:  "never",
+			servicePull:    "",
+			expectedPolicy: "never",
+		},
+
+		// Compose spec cases (no CLI override)
+		{
+			name:           "compose_always",
+			cliPullPolicy:  "",
+			servicePull:    "always",
+			expectedPolicy: "always",
+		},
+		{
+			name:           "compose_never",
+			cliPullPolicy:  "",
+			servicePull:    "never",
+			expectedPolicy: "never",
+		},
+		{
+			name:           "compose_missing",
+			cliPullPolicy:  "",
+			servicePull:    "missing",
+			expectedPolicy: "missing",
+		},
+		{
+			name:           "compose_if_not_present_maps_to_missing",
+			cliPullPolicy:  "",
+			servicePull:    "if_not_present",
+			expectedPolicy: "missing",
+		},
+
+		// Default case
+		{
+			name:           "neither_set_defaults_to_missing",
+			cliPullPolicy:  "",
+			servicePull:    "",
+			expectedPolicy: "missing",
+		},
+
+		// Error cases
+		{
+			name:          "compose_build_rejected",
+			cliPullPolicy: "",
+			servicePull:   "build",
+			expectError:   true,
+			errorContains: "not supported",
+		},
+		{
+			name:          "compose_refresh_rejected",
+			cliPullPolicy: "",
+			servicePull:   "refresh",
+			expectError:   true,
+			errorContains: "not supported",
+		},
+		{
+			name:          "compose_unknown_rejected",
+			cliPullPolicy: "",
+			servicePull:   "daily",
+			expectError:   true,
+			errorContains: "not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &types.ServiceConfig{
+				Name:       "web",
+				PullPolicy: tt.servicePull,
+			}
+
+			result, err := ResolvePullPolicy(tt.cliPullPolicy, service)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expectedPolicy {
+				t.Errorf("expected %q, got %q", tt.expectedPolicy, result)
+			}
+		})
+	}
+}
+
+func TestDeployServicePullPolicy(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx:latest",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		PullPolicy:            "always",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that the pre-pull command was executed (docker compose pull)
+	foundPrePull := false
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "pull" && i+1 < len(args) && args[i+1] == "web" {
+				foundPrePull = true
+				break
+			}
+		}
+	}
+	if !foundPrePull {
+		t.Error("expected docker compose pull command for always policy, got none")
+	}
+
+	// Verify that compose up/create commands contain --pull always
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		foundPull := false
+		for i, arg := range args {
+			if arg == "--pull" && i+1 < len(args) && args[i+1] == "always" {
+				foundPull = true
+				break
+			}
+		}
+		if !foundPull {
+			t.Errorf("expected --pull always in compose command, got args: %v", args)
+		}
+	}
+}
+
+func TestDeployServicePullPolicyFromComposeSpec(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:       "web",
+				Image:      "nginx:latest",
+				PullPolicy: "always",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that the pre-pull command was executed
+	foundPrePull := false
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "pull" && i+1 < len(args) && args[i+1] == "web" {
+				foundPrePull = true
+				break
+			}
+		}
+	}
+	if !foundPrePull {
+		t.Error("expected docker compose pull command for compose spec always policy, got none")
+	}
+
+	// Verify --pull always in compose up/create commands
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		foundPull := false
+		for i, arg := range args {
+			if arg == "--pull" && i+1 < len(args) && args[i+1] == "always" {
+				foundPull = true
+				break
+			}
+		}
+		if !foundPull {
+			t.Errorf("expected --pull always in compose command, got args: %v", args)
+		}
+	}
+}
+
+func TestDeployServicePullPolicyIfNotPresent(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:       "web",
+				Image:      "nginx:latest",
+				PullPolicy: "if_not_present",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify NO pre-pull command (only always triggers pre-pull)
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "pull" && i+1 < len(args) && args[i+1] == "web" {
+				t.Error("unexpected docker compose pull command for if_not_present policy")
+			}
+		}
+	}
+
+	// Verify --pull missing in compose up/create commands
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		foundPull := false
+		for i, arg := range args {
+			if arg == "--pull" && i+1 < len(args) && args[i+1] == "missing" {
+				foundPull = true
+				break
+			}
+		}
+		if !foundPull {
+			t.Errorf("expected --pull missing in compose command, got args: %v", args)
+		}
+	}
+}
+
+func TestDeployServicePullPolicyDefault(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx:latest",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify NO pre-pull command (default is missing, not always)
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "pull" && i+1 < len(args) && args[i+1] == "web" {
+				t.Error("unexpected docker compose pull command for default policy")
+			}
+		}
+	}
+
+	// Verify --pull missing in compose up/create commands
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		foundPull := false
+		for i, arg := range args {
+			if arg == "--pull" && i+1 < len(args) && args[i+1] == "missing" {
+				foundPull = true
+				break
+			}
+		}
+		if !foundPull {
+			t.Errorf("expected --pull missing in compose command, got args: %v", args)
+		}
+	}
+}
+
+func TestDeployServicePullPolicyBuildError(t *testing.T) {
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:       "web",
+				Image:      "nginx:latest",
+				PullPolicy: "build",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err == nil {
+		t.Fatal("expected error for build pull policy, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected error to contain 'not supported', got: %v", err)
+	}
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/test.bats
+++ b/test.bats
@@ -97,7 +97,7 @@ setup() {
 }
 
 teardown() {
-  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file bats-env-file; do
+  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file bats-env-file bats-pull-policy bats-pull-policy-ifnp; do
     docker compose -p "$project" down --remove-orphans --timeout 5 2>/dev/null || true
   done
 
@@ -527,4 +527,56 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_equal "env-file-works" "$output"
+}
+
+@test "pull policy from compose spec is respected" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/pull-policy"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-pull-policy web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify container is running
+  run docker ps --filter "label=com.docker.compose.project=bats-pull-policy" --filter "status=running" -q
+  echo "running containers: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+}
+
+@test "pull policy CLI flag overrides compose spec" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/pull-policy"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-pull-policy --pull missing web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify container is running
+  run docker ps --filter "label=com.docker.compose.project=bats-pull-policy" --filter "status=running" -q
+  echo "running containers: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+}
+
+@test "invalid pull policy is rejected" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/pull-policy"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-pull-policy --pull invalid web
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "invalid --pull value"
+}
+
+@test "pull policy if_not_present maps to missing" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/pull-policy-if-not-present"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-pull-policy-ifnp web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify container is running
+  run docker ps --filter "label=com.docker.compose.project=bats-pull-policy-ifnp" --filter "status=running" -q
+  echo "running containers: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
 }

--- a/tests/fixtures/pull-policy-if-not-present/docker-compose.yaml
+++ b/tests/fixtures/pull-policy-if-not-present/docker-compose.yaml
@@ -1,0 +1,4 @@
+services:
+  web:
+    image: nginx:latest
+    pull_policy: if_not_present

--- a/tests/fixtures/pull-policy/docker-compose.yaml
+++ b/tests/fixtures/pull-policy/docker-compose.yaml
@@ -1,0 +1,4 @@
+services:
+  web:
+    image: nginx:latest
+    pull_policy: always


### PR DESCRIPTION
## Summary

- Add `--pull` CLI flag to the deploy command (values: `always`, `missing`, `never`)
- Read compose spec `pull_policy` field as default; CLI `--pull` overrides it
- Default to `missing` when neither is set
- Map compose spec `if_not_present` to `missing`; reject `build` and `refresh` with an error
- Pass `--pull <value>` to all `docker compose up` and `docker compose create` invocations
- Run `docker compose pull <service>` before rolling update when policy is `always`

Closes #54