### PR TITLE
feat: add --build flag and support pull_policy: build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ docker orchestrate deploy --pull always
 docker orchestrate deploy --pull missing web
 ```
 
+Build images before deploying:
+
+```bash
+docker orchestrate deploy --build
+docker orchestrate deploy --build --pull never web
+```
+
 Deploy while skipping database services:
 
 ```bash
@@ -78,6 +85,7 @@ docker orchestrate deploy web --skip-databases
 
 ### Flags
 
+- `--build`: Build images before deploying. When specified, `docker compose build` is run before the rolling update and `--build` is passed to all compose commands. Only applies to services with a `build` section. Can be combined with `--pull`.
 - `--env-file`: Path to an environment variable file for compose file interpolation. Can be specified multiple times. When specified, these files are used instead of the default `.env` file. Environment variables from these files are also available to host scripts and container pre-stop scripts.
 - `-f, --file`: Path to a Compose configuration file. Can be specified multiple times to merge files (defaults to `docker-compose.yaml` or `docker-compose.yml`).
 - `-p, --project-name`: Specify an alternate project name (defaults to the directory name).
@@ -218,10 +226,29 @@ The effective pull policy is determined as follows:
 | `always` | Always pull the image before deploying. A `docker compose pull` is run before the rolling update to download the image once upfront. |
 | `missing` | Only pull the image if it is not already present locally. This is the default behavior. |
 | `never` | Never pull the image. The image must already be available locally. |
+| `build` | Build the image from a Dockerfile instead of pulling. Sets pull to `never` and runs `docker compose build` before the rolling update. Requires a `build` section in the service definition. |
 
 The compose spec value `if_not_present` is treated as `missing`.
 
-The compose spec values `build` and `refresh` are not supported and will produce an error.
+The compose spec value `refresh` is not supported and will produce an error.
+
+### Building Images
+
+The `--build` CLI flag triggers image building for services that have a `build` section in the compose file. When specified, `docker compose build` is run once before the rolling update, and `--build` is passed to all compose commands during deployment.
+
+```yaml
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    pull_policy: build
+```
+
+- The `--build` flag is silently ignored for services without a `build` section
+- `pull_policy: build` without a `build` section produces an error
+- `--build` can be combined with `--pull` (they are independent concerns)
+- When building, the pre-pull step is skipped since the image is built locally
 
 ## Script Extensions
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -18,6 +18,7 @@ import (
 type DeployCommand struct {
 	command.Meta
 
+	build                 bool
 	containerNameTemplate string
 	envFiles              []string
 	files                 []string
@@ -70,6 +71,7 @@ func (c *DeployCommand) ParsedArguments(args []string) (map[string]command.Argum
 
 func (c *DeployCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.BoolVar(&c.build, "build", false, "build images before deploying")
 	f.IntVar(&c.replicas, "replicas", 0, "the number of replicas to deploy")
 	f.StringSliceVar(&c.profiles, "profile", []string{}, "one or more profiles to enable")
 	f.StringVar(&c.containerNameTemplate, "container-name-template", "{{.ProjectName}}-{{.ServiceName}}-{{.InstanceID}}", "the template for the container name")
@@ -86,6 +88,7 @@ func (c *DeployCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
+			"--build":                   complete.PredictNothing,
 			"--container-name-template": complete.PredictAnything,
 			"--env-file":                complete.PredictFiles("*"),
 			"--file":                    complete.PredictFiles("*"),
@@ -176,6 +179,7 @@ func (c *DeployCommand) Run(args []string) int {
 
 		logger.LogHeader1(fmt.Sprintf("Deploying entire project from %s", strings.Join(c.files, ", ")))
 		err = internal.DeployProject(ctx, internal.DeployProjectInput{
+			Build:                 c.build,
 			Client:                client,
 			ComposeFiles:          c.files,
 			ContainerNameTemplate: c.containerNameTemplate,
@@ -197,6 +201,7 @@ func (c *DeployCommand) Run(args []string) int {
 
 	logger.LogHeader2(fmt.Sprintf("Deploying service %s", serviceName))
 	err = internal.DeployService(ctx, internal.DeployServiceInput{
+		Build:                 c.build,
 		Client:                client,
 		ComposeFiles:          c.files,
 		ContainerNameTemplate: c.containerNameTemplate,

--- a/internal/compose.go
+++ b/internal/compose.go
@@ -128,6 +128,8 @@ func composeContainers(ctx context.Context, input ComposeContainersInput) ([]con
 
 // RollingUpdateInput contains the parameters for rolling update
 type RollingUpdateInput struct {
+	// Build is whether to build images before deploying
+	Build bool
 	// Client is the Docker client to use. If nil, a new one will be created.
 	Client DockerClientInterface
 	// ComposeFiles is the list of paths to the compose files
@@ -260,8 +262,11 @@ func rollingUpdateBatchStartFirst(ctx context.Context, input RollingUpdateInput,
 	args := []string{"compose"}
 	args = append(args, composeFileArgs(input.ComposeFiles)...)
 	args = append(args, envFileArgs(input.EnvFiles)...)
-	args = append(args, "-p", input.ProjectName, "up", "--detach",
-		"--pull", input.PullPolicy,
+	args = append(args, "-p", input.ProjectName, "up", "--detach")
+	if input.Build {
+		args = append(args, "--build")
+	}
+	args = append(args, "--pull", input.PullPolicy,
 		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, newScale),
 		"--no-deps", "--no-recreate", input.ServiceName)
 	_, err = input.Executor(ctx, ExecCommandInput{
@@ -554,8 +559,11 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 	args := []string{"compose"}
 	args = append(args, composeFileArgs(input.ComposeFiles)...)
 	args = append(args, envFileArgs(input.EnvFiles)...)
-	args = append(args, "-p", input.ProjectName, "up", "--detach",
-		"--pull", input.PullPolicy,
+	args = append(args, "-p", input.ProjectName, "up", "--detach")
+	if input.Build {
+		args = append(args, "--build")
+	}
+	args = append(args, "--pull", input.PullPolicy,
 		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, targetScale),
 		"--no-deps", "--no-recreate", input.ServiceName)
 	_, err = input.Executor(ctx, ExecCommandInput{
@@ -811,6 +819,8 @@ func scaleDownContainers(ctx context.Context, input ScaleDownContainersInput) er
 
 // ScaleUpContainersInput is the input for the scaleUpContainers function
 type ScaleUpContainersInput struct {
+	// Build is whether to build images before deploying
+	Build bool
 	// Client is the Docker client to use. If nil, a new one will be created.
 	Client DockerClientInterface
 	// ComposeFiles is the list of paths to the compose files
@@ -882,8 +892,11 @@ func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error 
 	args := []string{"compose"}
 	args = append(args, composeFileArgs(input.ComposeFiles)...)
 	args = append(args, envFileArgs(input.EnvFiles)...)
-	args = append(args, "-p", input.ProjectName, "create",
-		"--pull", input.PullPolicy,
+	args = append(args, "-p", input.ProjectName, "create")
+	if input.Build {
+		args = append(args, "--build")
+	}
+	args = append(args, "--pull", input.PullPolicy,
 		"--scale", fmt.Sprintf("%s=%d", input.ServiceName, input.DesiredReplicas),
 		input.ServiceName)
 	_, err := executor(ctx, ExecCommandInput{

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -18,6 +18,8 @@ import (
 
 // DeployProjectInput is the input for the DeployProject function
 type DeployProjectInput struct {
+	// Build is whether to build images before deploying
+	Build bool
 	// Client is the Docker client to use
 	Client DockerClientInterface
 	// ComposeFiles is the list of paths to the compose files
@@ -52,6 +54,7 @@ func DeployProject(ctx context.Context, input DeployProjectInput) error {
 	for _, serviceName := range orderedServices {
 		input.Logger.LogHeader2(fmt.Sprintf("Deploying service %s", serviceName))
 		err = DeployService(ctx, DeployServiceInput{
+			Build:                 input.Build,
 			Client:                input.Client,
 			ComposeFiles:          input.ComposeFiles,
 			ContainerNameTemplate: input.ContainerNameTemplate,
@@ -139,6 +142,8 @@ func RemoveMissingServices(ctx context.Context, input DeployProjectInput, ordere
 
 // DeployServiceInput is the input for the DeployService function
 type DeployServiceInput struct {
+	// Build is whether to build images before deploying
+	Build bool
 	// Client is the Docker client to use
 	Client DockerClientInterface
 	// ComposeFiles is the list of paths to the compose files
@@ -205,7 +210,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 		return nil
 	}
 
-	pullPolicy, err := ResolvePullPolicy(input.PullPolicy, service)
+	pullPolicy, buildImage, err := ResolvePullPolicy(input.PullPolicy, input.Build, service)
 	if err != nil {
 		return err
 	}
@@ -352,8 +357,25 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 		}
 	}
 
-	// Pre-pull image when pull policy is "always" to avoid redundant pulls during each batch
-	if pullPolicy == "always" {
+	// Pre-build image when build flag is set
+	if buildImage {
+		input.Logger.Info(fmt.Sprintf("Building image for service %s", input.ServiceName))
+		buildArgs := []string{"compose"}
+		buildArgs = append(buildArgs, composeFileArgs(input.ComposeFiles)...)
+		buildArgs = append(buildArgs, envFileArgs(input.EnvFiles)...)
+		buildArgs = append(buildArgs, "-p", input.ProjectName, "build", input.ServiceName)
+		_, err = executor(ctx, ExecCommandInput{
+			Command:          "docker",
+			Args:             buildArgs,
+			WorkingDirectory: projectDir,
+		})
+		if err != nil {
+			return fmt.Errorf("error building image for service %s: %v", input.ServiceName, err)
+		}
+	}
+
+	// Pre-pull image when pull policy is "always" and not building
+	if pullPolicy == "always" && !buildImage {
 		input.Logger.Info(fmt.Sprintf("Pulling image for service %s", input.ServiceName))
 		pullArgs := []string{"compose"}
 		pullArgs = append(pullArgs, composeFileArgs(input.ComposeFiles)...)
@@ -429,6 +451,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	var rollingUpdateOutput RollingUpdateOutput
 	if len(containersToUpdate) > 0 {
 		rollingUpdateOutput, err = rollingUpdateContainers(ctx, RollingUpdateInput{
+			Build:                       buildImage,
 			Client:                      input.Client,
 			ComposeFiles:                input.ComposeFiles,
 			ContainersToUpdate:          containersToUpdate,
@@ -476,6 +499,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 	// Scale up if needed (only after existing containers are replaced)
 	if len(updatedContainers) < replicas {
 		err := scaleUpContainers(ctx, ScaleUpContainersInput{
+			Build:                       buildImage,
 			Client:                      input.Client,
 			ComposeFiles:                input.ComposeFiles,
 			CurrentReplicas:             len(updatedContainers),
@@ -707,32 +731,46 @@ func isDatabaseService(serviceImage string, logger *command.ZerologUi) bool {
 	return false
 }
 
-// ResolvePullPolicy resolves the effective pull policy from the CLI flag and compose spec.
-// CLI flag takes precedence. If neither is set, defaults to "missing".
+// ResolvePullPolicy resolves the effective pull policy and build flag from CLI flags and compose spec.
+// CLI flags take precedence. If neither pull policy is set, defaults to "missing".
 // Compose spec "if_not_present" is mapped to "missing".
-// Compose spec "build" and "refresh" are not supported and return an error.
-func ResolvePullPolicy(cliPullPolicy string, service *types.ServiceConfig) (string, error) {
+// Compose spec "build" sets pull to "never" and build to true (requires a build section).
+// The --build CLI flag enables building for services that have a build section.
+func ResolvePullPolicy(cliPullPolicy string, cliBuild bool, service *types.ServiceConfig) (string, bool, error) {
+	build := false
+
+	// Resolve build flag
+	if service.PullPolicy == types.PullPolicyBuild {
+		if service.Build == nil {
+			return "", false, fmt.Errorf("pull_policy 'build' requires a build section in service %s", service.Name)
+		}
+		build = true
+	} else if cliBuild && service.Build != nil {
+		build = true
+	}
+
+	// Resolve pull policy
 	if cliPullPolicy != "" {
-		return cliPullPolicy, nil
+		return cliPullPolicy, build, nil
 	}
 
 	switch service.PullPolicy {
 	case "":
-		return "missing", nil
+		return "missing", build, nil
 	case types.PullPolicyAlways:
-		return "always", nil
+		return "always", build, nil
 	case types.PullPolicyNever:
-		return "never", nil
+		return "never", build, nil
 	case types.PullPolicyMissing:
-		return "missing", nil
+		return "missing", build, nil
 	case types.PullPolicyIfNotPresent:
-		return "missing", nil
+		return "missing", build, nil
 	case types.PullPolicyBuild:
-		return "", fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
+		return "never", build, nil
 	case types.PullPolicyRefresh:
-		return "", fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
+		return "", false, fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
 	default:
-		return "", fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
+		return "", false, fmt.Errorf("pull_policy '%s' is not supported by docker-orchestrate", service.PullPolicy)
 	}
 }
 

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -1720,11 +1720,16 @@ func TestDeployServiceEnvVarsPassedToHooks(t *testing.T) {
 }
 
 func TestResolvePullPolicy(t *testing.T) {
+	buildConfig := &types.BuildConfig{Context: "."}
+
 	tests := []struct {
 		name           string
 		cliPullPolicy  string
+		cliBuild       bool
 		servicePull    string
+		serviceBuild   *types.BuildConfig
 		expectedPolicy string
+		expectedBuild  bool
 		expectError    bool
 		errorContains  string
 	}{
@@ -1751,25 +1756,21 @@ func TestResolvePullPolicy(t *testing.T) {
 		// Compose spec cases (no CLI override)
 		{
 			name:           "compose_always",
-			cliPullPolicy:  "",
 			servicePull:    "always",
 			expectedPolicy: "always",
 		},
 		{
 			name:           "compose_never",
-			cliPullPolicy:  "",
 			servicePull:    "never",
 			expectedPolicy: "never",
 		},
 		{
 			name:           "compose_missing",
-			cliPullPolicy:  "",
 			servicePull:    "missing",
 			expectedPolicy: "missing",
 		},
 		{
 			name:           "compose_if_not_present_maps_to_missing",
-			cliPullPolicy:  "",
 			servicePull:    "if_not_present",
 			expectedPolicy: "missing",
 		},
@@ -1777,29 +1778,70 @@ func TestResolvePullPolicy(t *testing.T) {
 		// Default case
 		{
 			name:           "neither_set_defaults_to_missing",
-			cliPullPolicy:  "",
-			servicePull:    "",
 			expectedPolicy: "missing",
+		},
+
+		// Build cases
+		{
+			name:           "compose_build_with_build_section",
+			servicePull:    "build",
+			serviceBuild:   buildConfig,
+			expectedPolicy: "never",
+			expectedBuild:  true,
+		},
+		{
+			name:          "compose_build_without_build_section",
+			servicePull:   "build",
+			expectError:   true,
+			errorContains: "requires a build section",
+		},
+		{
+			name:           "cli_build_with_build_section",
+			cliBuild:       true,
+			serviceBuild:   buildConfig,
+			expectedPolicy: "missing",
+			expectedBuild:  true,
+		},
+		{
+			name:           "cli_build_without_build_section",
+			cliBuild:       true,
+			expectedPolicy: "missing",
+			expectedBuild:  false,
+		},
+		{
+			name:           "cli_build_with_cli_pull_always",
+			cliPullPolicy:  "always",
+			cliBuild:       true,
+			serviceBuild:   buildConfig,
+			expectedPolicy: "always",
+			expectedBuild:  true,
+		},
+		{
+			name:           "cli_build_with_compose_pull_never",
+			cliBuild:       true,
+			servicePull:    "never",
+			serviceBuild:   buildConfig,
+			expectedPolicy: "never",
+			expectedBuild:  true,
+		},
+		{
+			name:           "compose_build_with_cli_pull_override",
+			cliPullPolicy:  "always",
+			servicePull:    "build",
+			serviceBuild:   buildConfig,
+			expectedPolicy: "always",
+			expectedBuild:  true,
 		},
 
 		// Error cases
 		{
-			name:          "compose_build_rejected",
-			cliPullPolicy: "",
-			servicePull:   "build",
-			expectError:   true,
-			errorContains: "not supported",
-		},
-		{
 			name:          "compose_refresh_rejected",
-			cliPullPolicy: "",
 			servicePull:   "refresh",
 			expectError:   true,
 			errorContains: "not supported",
 		},
 		{
 			name:          "compose_unknown_rejected",
-			cliPullPolicy: "",
 			servicePull:   "daily",
 			expectError:   true,
 			errorContains: "not supported",
@@ -1811,9 +1853,10 @@ func TestResolvePullPolicy(t *testing.T) {
 			service := &types.ServiceConfig{
 				Name:       "web",
 				PullPolicy: tt.servicePull,
+				Build:      tt.serviceBuild,
 			}
 
-			result, err := ResolvePullPolicy(tt.cliPullPolicy, service)
+			result, build, err := ResolvePullPolicy(tt.cliPullPolicy, tt.cliBuild, service)
 			if tt.expectError {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -1828,7 +1871,10 @@ func TestResolvePullPolicy(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if result != tt.expectedPolicy {
-				t.Errorf("expected %q, got %q", tt.expectedPolicy, result)
+				t.Errorf("expected policy %q, got %q", tt.expectedPolicy, result)
+			}
+			if build != tt.expectedBuild {
+				t.Errorf("expected build %v, got %v", tt.expectedBuild, build)
 			}
 		})
 	}
@@ -2203,7 +2249,121 @@ func TestDeployServicePullPolicyDefault(t *testing.T) {
 	}
 }
 
-func TestDeployServicePullPolicyBuildError(t *testing.T) {
+func TestDeployServicePullPolicyBuild(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:       "web",
+				Image:      "nginx:latest",
+				PullPolicy: "build",
+				Build:      &types.BuildConfig{Context: "."},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify pre-build command was executed
+	foundPreBuild := false
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "build" && i+1 < len(args) && args[i+1] == "web" {
+				foundPreBuild = true
+				break
+			}
+		}
+	}
+	if !foundPreBuild {
+		t.Error("expected docker compose build command for pull_policy: build, got none")
+	}
+
+	// Verify NO pre-pull command
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "pull" && i+1 < len(args) && args[i+1] == "web" {
+				t.Error("unexpected docker compose pull command when building")
+			}
+		}
+	}
+
+	// Verify compose up/create commands contain --build and --pull never
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		foundBuild := false
+		foundPullNever := false
+		for i, arg := range args {
+			if arg == "--build" {
+				foundBuild = true
+			}
+			if arg == "--pull" && i+1 < len(args) && args[i+1] == "never" {
+				foundPullNever = true
+			}
+		}
+		if !foundBuild {
+			t.Errorf("expected --build in compose command, got args: %v", args)
+		}
+		if !foundPullNever {
+			t.Errorf("expected --pull never in compose command, got args: %v", args)
+		}
+	}
+}
+
+func TestDeployServicePullPolicyBuildNoBuildSection(t *testing.T) {
 	mockClient := &mockDockerClient{
 		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
 			return []container.Summary{}, nil
@@ -2244,10 +2404,197 @@ func TestDeployServicePullPolicyBuildError(t *testing.T) {
 		ServiceName:           "web",
 	})
 	if err == nil {
-		t.Fatal("expected error for build pull policy, got nil")
+		t.Fatal("expected error for pull_policy: build without build section, got nil")
 	}
-	if !strings.Contains(err.Error(), "not supported") {
-		t.Errorf("expected error to contain 'not supported', got: %v", err)
+	if !strings.Contains(err.Error(), "requires a build section") {
+		t.Errorf("expected error to contain 'requires a build section', got: %v", err)
+	}
+}
+
+func TestDeployServiceBuildFlag(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx:latest",
+				Build: &types.BuildConfig{Context: "."},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Build:                 true,
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify pre-build command was executed
+	foundPreBuild := false
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "build" && i+1 < len(args) && args[i+1] == "web" {
+				foundPreBuild = true
+				break
+			}
+		}
+	}
+	if !foundPreBuild {
+		t.Error("expected docker compose build command for --build flag, got none")
+	}
+
+	// Verify compose up/create commands contain --build and --pull missing (default)
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		foundBuild := false
+		foundPullMissing := false
+		for i, arg := range args {
+			if arg == "--build" {
+				foundBuild = true
+			}
+			if arg == "--pull" && i+1 < len(args) && args[i+1] == "missing" {
+				foundPullMissing = true
+			}
+		}
+		if !foundBuild {
+			t.Errorf("expected --build in compose command, got args: %v", args)
+		}
+		if !foundPullMissing {
+			t.Errorf("expected --pull missing in compose command, got args: %v", args)
+		}
+	}
+}
+
+func TestDeployServiceBuildFlagNoBuildSection(t *testing.T) {
+	var executedArgs [][]string
+
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{}, nil
+		},
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedArgs = append(executedArgs, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx:latest",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	err := DeployService(context.Background(), DeployServiceInput{
+		Build:                 true,
+		Client:                mockClient,
+		Executor:              mockExecutor,
+		ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+		ContainerNameTemplate: "{{.ServiceName}}",
+		Logger:                logger,
+		Project:               project,
+		ProjectName:           "test",
+		ServiceName:           "web",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify NO pre-build command (service has no build section)
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		for i, arg := range args {
+			if arg == "build" && i+1 < len(args) && args[i+1] == "web" {
+				t.Error("unexpected docker compose build command for service without build section")
+			}
+		}
+	}
+
+	// Verify compose up/create commands do NOT contain --build
+	for _, args := range executedArgs {
+		if args[0] != "compose" {
+			continue
+		}
+		hasUp := false
+		hasCreate := false
+		for _, arg := range args {
+			if arg == "up" {
+				hasUp = true
+			}
+			if arg == "create" {
+				hasCreate = true
+			}
+		}
+		if !hasUp && !hasCreate {
+			continue
+		}
+		for _, arg := range args {
+			if arg == "--build" {
+				t.Errorf("unexpected --build in compose command for service without build section, got args: %v", args)
+			}
+		}
 	}
 }
 

--- a/test.bats
+++ b/test.bats
@@ -97,7 +97,7 @@ setup() {
 }
 
 teardown() {
-  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file bats-env-file bats-pull-policy bats-pull-policy-ifnp; do
+  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file bats-env-file bats-pull-policy bats-pull-policy-ifnp bats-pull-policy-build; do
     docker compose -p "$project" down --remove-orphans --timeout 5 2>/dev/null || true
   done
 
@@ -577,6 +577,34 @@ teardown() {
 
   # Verify container is running
   run docker ps --filter "label=com.docker.compose.project=bats-pull-policy-ifnp" --filter "status=running" -q
+  echo "running containers: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+}
+
+@test "pull policy build from compose spec builds and deploys" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/pull-policy-build"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-pull-policy-build web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify container is running
+  run docker ps --filter "label=com.docker.compose.project=bats-pull-policy-build" --filter "status=running" -q
+  echo "running containers: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+}
+
+@test "build CLI flag builds and deploys" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/pull-policy-build"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-pull-policy-build --build --pull never web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify container is running
+  run docker ps --filter "label=com.docker.compose.project=bats-pull-policy-build" --filter "status=running" -q
   echo "running containers: $output"
   assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
 }

--- a/tests/fixtures/pull-policy-build/Dockerfile
+++ b/tests/fixtures/pull-policy-build/Dockerfile
@@ -1,0 +1,1 @@
+FROM nginx:latest

--- a/tests/fixtures/pull-policy-build/docker-compose.yaml
+++ b/tests/fixtures/pull-policy-build/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    pull_policy: build


### PR DESCRIPTION
## Summary

- Add `--build` CLI flag that triggers `docker compose build` before the rolling update and passes `--build` to all compose commands
- Support `pull_policy: build` from the compose spec — sets pull to `never` and enables building
- `pull_policy: build` requires a `build:` section; errors without one
- `--build` CLI flag is silently ignored for services without a `build:` section (safe for mixed projects)
- When building, the pre-pull step is skipped
- `--build` and `--pull` are independent and can be combined

Closes #73