### PR TITLE
Add x-wait-after-healthy extension for post-healthcheck delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,27 @@ services:
 - When `x-healthcheck-wait` is set, the health check timeout becomes `(monitor + x-healthcheck-wait) * 2`, giving enough room for polling plus the wait. The `monitor` field still controls the polling interval.
 - The wait is applied after the container reaches the running state but before the `x-healthcheck-host-command` (if any) is executed.
 
+### Wait After Healthy
+
+The `x-wait-after-healthy` extension adds a delay after a container becomes healthy before proceeding with the deployment (e.g., stopping the old container in a rolling update). This gives reverse proxies (Traefik, nginx-proxy) time to detect the new container and update their routing before the old container is removed.
+
+```yaml
+services:
+  web:
+    image: myapp:latest
+    deploy:
+      replicas: 3
+      update_config:
+        parallelism: 1
+        order: start-first
+        x-wait-after-healthy: "5s"
+```
+
+- The value must be a valid Go duration string (e.g., `"5s"`, `"500ms"`, `"1m30s"`)
+- Applies regardless of whether a Docker healthcheck is defined — the delay happens after all healthcheck validation passes (including `x-healthcheck-host-command` if configured).
+- If not specified, no additional delay is added after the container becomes healthy (existing behavior).
+- The delay is applied per-container, after the healthcheck passes but before the old container's stop sequence begins.
+
 ### Stop Commands
 
 The tool supports several types of stop commands that are executed before and after a container is terminated (e.g., during a rolling update or scale down):
@@ -456,12 +477,13 @@ If a post_start hook fails, the container is treated as failed: the pre-stop cle
 1. Container start
 2. Compose spec `post_start` hooks (commands inside the container)
 3. Docker healthcheck (or `x-healthcheck-wait` for containers without healthchecks) + `x-healthcheck-host-command`
-4. _...service runs..._
-5. `x-pre-stop-host-command` (on the host)
-6. `x-pre-stop-command` (script inside the container)
-7. Compose spec `pre_stop` hooks (commands inside the container)
-8. Container stop + remove
-9. `x-post-stop-host-command` (on the host)
+4. `x-wait-after-healthy` delay (if configured)
+5. _...service runs..._
+6. `x-pre-stop-host-command` (on the host)
+7. `x-pre-stop-command` (script inside the container)
+8. Compose spec `pre_stop` hooks (commands inside the container)
+9. Container stop + remove
+10. `x-post-stop-host-command` (on the host)
 
 #### Detached Execution
 

--- a/internal/compose.go
+++ b/internal/compose.go
@@ -154,6 +154,8 @@ type RollingUpdateInput struct {
 	HealthcheckCommand string
 	// HealthcheckWait is the duration to wait before considering a container without a Docker healthcheck as healthy
 	HealthcheckWait time.Duration
+	// WaitAfterHealthy is the duration to wait after a container becomes healthy before proceeding
+	WaitAfterHealthy time.Duration
 	// Logger is the logger to use
 	Logger *command.ZerologUi
 	// MaxFailureRatio is the maximum allowed failure ratio
@@ -401,6 +403,11 @@ func rollingUpdateBatchStartFirst(ctx context.Context, input RollingUpdateInput,
 				// We don't return error here because we want to continue with others in batch
 				// but we check failure ratio later
 				return
+			}
+
+			if input.WaitAfterHealthy > 0 {
+				input.Logger.Info(fmt.Sprintf("Waiting after healthy: %v for container %s", input.WaitAfterHealthy, newContainer.ID[:12]))
+				input.Sleeper(input.WaitAfterHealthy)
 			}
 
 			// Pop an old container to stop
@@ -666,6 +673,12 @@ func rollingUpdateBatchStopFirst(ctx context.Context, input RollingUpdateInput, 
 				})
 				return
 			}
+
+			if input.WaitAfterHealthy > 0 {
+				input.Logger.Info(fmt.Sprintf("Waiting after healthy: %v for container %s", input.WaitAfterHealthy, newContainer.ID[:12]))
+				input.Sleeper(input.WaitAfterHealthy)
+			}
+
 			input.Logger.Info(fmt.Sprintf("Container %s is healthy", newContainer.ID[:12]))
 		}(nc)
 	}
@@ -849,6 +862,8 @@ type ScaleUpContainersInput struct {
 	HealthcheckCommand string
 	// HealthcheckWait is the duration to wait before considering a container without a Docker healthcheck as healthy
 	HealthcheckWait time.Duration
+	// WaitAfterHealthy is the duration to wait after a container becomes healthy before proceeding
+	WaitAfterHealthy time.Duration
 	// Logger is the logger to use
 	Logger *command.ZerologUi
 	// MaxFailureRatio is the maximum allowed failure ratio
@@ -867,6 +882,8 @@ type ScaleUpContainersInput struct {
 	PullPolicy string
 	// ServiceName is the name of the service
 	ServiceName string
+	// Sleeper is the function to use for sleeping. If nil, time.Sleep will be used.
+	Sleeper func(time.Duration)
 	// PreStopHostCommand is the command to run before stopping a container (on host)
 	PreStopHostCommand string
 	// PreStopHostCommandDetached indicates if the pre-stop host command should run detached
@@ -888,6 +905,10 @@ type ScaleUpContainersInput struct {
 // scaleUpContainers scales up containers by creating and starting new ones
 func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error {
 	input.Logger.Info(fmt.Sprintf("Scaling up containers: service=%s, current-replicas=%d, parallelism=%d, target-replicas=%d", input.ServiceName, input.CurrentReplicas, input.Parallelism, input.DesiredReplicas))
+
+	if input.Sleeper == nil {
+		input.Sleeper = time.Sleep
+	}
 
 	executor := input.Executor
 	if executor == nil {
@@ -1108,6 +1129,9 @@ func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error 
 						ScriptType:  "post-stop",
 						ServiceName: input.ServiceName,
 					})
+				} else if input.WaitAfterHealthy > 0 {
+					input.Logger.Info(fmt.Sprintf("Waiting after healthy: %v for container %s", input.WaitAfterHealthy, c.ID[:12]))
+					input.Sleeper(input.WaitAfterHealthy)
 				}
 			}(c)
 		}
@@ -1134,7 +1158,7 @@ func scaleUpContainers(ctx context.Context, input ScaleUpContainersInput) error 
 		// Wait for delay between batches (except for the last batch)
 		if i+batchSize < len(createdContainers) && input.Delay > 0 {
 			input.Logger.Info(fmt.Sprintf("Waiting before next batch: %v", input.Delay))
-			time.Sleep(input.Delay)
+			input.Sleeper(input.Delay)
 		}
 	}
 

--- a/internal/compose_test.go
+++ b/internal/compose_test.go
@@ -1799,3 +1799,312 @@ func TestPreStopHooksExecutionOrder(t *testing.T) {
 		}
 	})
 }
+
+func TestRollingUpdateBatchStartFirstWaitAfterHealthy(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	t.Run("sleeper called with correct duration after healthy", func(t *testing.T) {
+		var sleeperDurations []time.Duration
+		listCallCount := 0
+		mock := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				listCallCount++
+				if listCallCount == 1 {
+					return []container.Summary{
+						{ID: "old1_container_id", Created: 50},
+					}, nil
+				}
+				return []container.Summary{
+					{ID: "old1_container_id", Created: 50},
+					{ID: "new1_container_id", Created: 300},
+				}, nil
+			},
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Running: true,
+						},
+					},
+				}, nil
+			},
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
+				return nil
+			},
+		}
+
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		batch := []container.Summary{
+			{ID: "old1_container_id", Created: 50},
+		}
+
+		input := RollingUpdateInput{
+			Client:             mock,
+			Executor:           executor,
+			Logger:             logger,
+			ProjectName:        "proj",
+			ServiceName:        "web",
+			Parallelism:        1,
+			MaxFailureRatio:    0,
+			ContainersToUpdate: batch,
+			WaitAfterHealthy:   5 * time.Second,
+			Sleeper: func(d time.Duration) {
+				sleeperDurations = append(sleeperDurations, d)
+			},
+			StopTimeout: 10,
+			TickerCh:    testTickerCh(),
+		}
+
+		output := &RollingUpdateOutput{}
+		err := rollingUpdateBatchStartFirst(ctx, input, batch, output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		found := false
+		for _, d := range sleeperDurations {
+			if d == 5*time.Second {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected sleeper to be called with 5s, got calls: %v", sleeperDurations)
+		}
+	})
+
+	t.Run("no sleep when WaitAfterHealthy is zero", func(t *testing.T) {
+		buf.Reset()
+		var sleeperCalled bool
+		listCallCount := 0
+		mock := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				listCallCount++
+				if listCallCount == 1 {
+					return []container.Summary{
+						{ID: "old1_container_id", Created: 50},
+					}, nil
+				}
+				return []container.Summary{
+					{ID: "old1_container_id", Created: 50},
+					{ID: "new1_container_id", Created: 300},
+				}, nil
+			},
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Running: true,
+						},
+					},
+				}, nil
+			},
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
+				return nil
+			},
+		}
+
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		batch := []container.Summary{
+			{ID: "old1_container_id", Created: 50},
+		}
+
+		input := RollingUpdateInput{
+			Client:             mock,
+			Executor:           executor,
+			Logger:             logger,
+			ProjectName:        "proj",
+			ServiceName:        "web",
+			Parallelism:        1,
+			MaxFailureRatio:    0,
+			ContainersToUpdate: batch,
+			WaitAfterHealthy:   0,
+			Sleeper: func(d time.Duration) {
+				sleeperCalled = true
+			},
+			StopTimeout: 10,
+			TickerCh:    testTickerCh(),
+		}
+
+		output := &RollingUpdateOutput{}
+		err := rollingUpdateBatchStartFirst(ctx, input, batch, output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if sleeperCalled {
+			t.Error("expected sleeper not to be called when WaitAfterHealthy is 0")
+		}
+	})
+}
+
+func TestRollingUpdateBatchStopFirstWaitAfterHealthy(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	t.Run("sleeper called with correct duration after healthy", func(t *testing.T) {
+		var sleeperDurations []time.Duration
+		listCallCount := 0
+		mock := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				listCallCount++
+				if listCallCount == 1 {
+					return []container.Summary{}, nil
+				}
+				return []container.Summary{
+					{ID: "new1_container_id", Created: 300},
+				}, nil
+			},
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Running: true,
+						},
+					},
+				}, nil
+			},
+			containerTerminate: func(ctx context.Context, id string, timeoutSeconds int) error {
+				return nil
+			},
+		}
+
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		batch := []container.Summary{
+			{ID: "old1_container_id", Created: 50},
+		}
+
+		input := RollingUpdateInput{
+			Client:             mock,
+			Executor:           executor,
+			Logger:             logger,
+			ProjectName:        "proj",
+			ServiceName:        "web",
+			Parallelism:        1,
+			MaxFailureRatio:    0,
+			ContainersToUpdate: batch,
+			WaitAfterHealthy:   3 * time.Second,
+			Sleeper: func(d time.Duration) {
+				sleeperDurations = append(sleeperDurations, d)
+			},
+			StopTimeout: 10,
+			TickerCh:    testTickerCh(),
+		}
+
+		output := &RollingUpdateOutput{}
+		err := rollingUpdateBatchStopFirst(ctx, input, batch, output)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		found := false
+		for _, d := range sleeperDurations {
+			if d == 3*time.Second {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected sleeper to be called with 3s, got calls: %v", sleeperDurations)
+		}
+	})
+}
+
+func TestScaleUpContainersWaitAfterHealthy(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	t.Run("sleeper called with correct duration after healthy", func(t *testing.T) {
+		var sleeperDurations []time.Duration
+		listCallCount := 0
+		mock := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				listCallCount++
+				return []container.Summary{
+					{ID: "new1_container_id", Created: 300},
+				}, nil
+			},
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Running: true,
+						},
+					},
+				}, nil
+			},
+			containerStart: func(ctx context.Context, id string, options container.StartOptions) error {
+				return nil
+			},
+		}
+
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		input := ScaleUpContainersInput{
+			Client:          mock,
+			Executor:        executor,
+			Logger:          logger,
+			ProjectName:     "proj",
+			ProjectDir:      "/tmp",
+			ServiceName:     "web",
+			ComposeFiles:    []string{"/tmp/docker-compose.yaml"},
+			Parallelism:     1,
+			CurrentReplicas: 0,
+			DesiredReplicas: 1,
+			WaitAfterHealthy: 4 * time.Second,
+			Sleeper: func(d time.Duration) {
+				sleeperDurations = append(sleeperDurations, d)
+			},
+			TickerCh: testTickerCh(),
+		}
+
+		err := scaleUpContainers(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		found := false
+		for _, d := range sleeperDurations {
+			if d == 4*time.Second {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected sleeper to be called with 4s, got calls: %v", sleeperDurations)
+		}
+	})
+}

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -269,6 +269,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 
 	healthcheckHostCommand := ""
 	healthcheckWait := time.Duration(0)
+	waitAfterHealthy := time.Duration(0)
 	preStopHostCommand := ""
 	preStopCommand := ""
 	postStopHostCommand := ""
@@ -284,6 +285,13 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 				return fmt.Errorf("invalid x-healthcheck-wait duration %q: %v", waitStr, err)
 			}
 			healthcheckWait = parsed
+		}
+		if waitStr, ok := updateConfig.Extensions["x-wait-after-healthy"].(string); ok {
+			parsed, err := time.ParseDuration(waitStr)
+			if err != nil {
+				return fmt.Errorf("invalid x-wait-after-healthy duration %q: %v", waitStr, err)
+			}
+			waitAfterHealthy = parsed
 		}
 		if cmd, ok := updateConfig.Extensions["x-pre-stop-host-command"].(string); ok {
 			preStopHostCommand = cmd
@@ -472,6 +480,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			FailureAction:               updateConfig.FailureAction,
 			HealthcheckCommand:          healthcheckHostCommand,
 			HealthcheckWait:             healthcheckWait,
+			WaitAfterHealthy:            waitAfterHealthy,
 			Logger:                      input.Logger,
 			MaxFailureRatio:             maxFailureRatio,
 			Monitor:                     monitor,
@@ -521,6 +530,7 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 			FailureAction:               string(updateConfig.FailureAction),
 			HealthcheckCommand:          healthcheckHostCommand,
 			HealthcheckWait:             healthcheckWait,
+			WaitAfterHealthy:            waitAfterHealthy,
 			Logger:                      input.Logger,
 			MaxFailureRatio:             maxFailureRatio,
 			Monitor:                     monitor,

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -2598,6 +2598,114 @@ func TestDeployServiceBuildFlagNoBuildSection(t *testing.T) {
 	}
 }
 
+func TestDeployServiceWaitAfterHealthy(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	t.Run("valid x-wait-after-healthy is parsed without error", func(t *testing.T) {
+		buf.Reset()
+		callCount := 0
+
+		mockClient := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				callCount++
+				return []container.Summary{}, nil
+			},
+		}
+
+		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		project := &types.Project{
+			Services: types.Services{
+				"web": types.ServiceConfig{
+					Name: "web",
+					Deploy: &types.DeployConfig{
+						UpdateConfig: &types.UpdateConfig{
+							Extensions: map[string]interface{}{
+								"x-wait-after-healthy": "5s",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		input := DeployServiceInput{
+			Client:                mockClient,
+			Executor:              mockExecutor,
+			ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+			ContainerNameTemplate: "{{.ServiceName}}",
+			Logger:                logger,
+			Project:               project,
+			ProjectName:           "test",
+			ServiceName:           "web",
+		}
+
+		err := DeployService(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid x-wait-after-healthy returns error", func(t *testing.T) {
+		buf.Reset()
+		callCount := 0
+
+		mockClient := &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				callCount++
+				return []container.Summary{}, nil
+			},
+		}
+
+		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		project := &types.Project{
+			Services: types.Services{
+				"web": types.ServiceConfig{
+					Name: "web",
+					Deploy: &types.DeployConfig{
+						UpdateConfig: &types.UpdateConfig{
+							Extensions: map[string]interface{}{
+								"x-wait-after-healthy": "not-a-duration",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		input := DeployServiceInput{
+			Client:                mockClient,
+			Executor:              mockExecutor,
+			ComposeFiles:          []string{"/tmp/docker-compose.yaml"},
+			ContainerNameTemplate: "{{.ServiceName}}",
+			Logger:                logger,
+			Project:               project,
+			ProjectName:           "test",
+			ServiceName:           "web",
+		}
+
+		err := DeployService(context.Background(), input)
+		if err == nil {
+			t.Fatal("expected error for invalid duration, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid x-wait-after-healthy duration") {
+			t.Errorf("expected error about invalid duration, got: %v", err)
+		}
+	})
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/test.bats
+++ b/test.bats
@@ -97,7 +97,7 @@ setup() {
 }
 
 teardown() {
-  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file bats-env-file bats-pull-policy bats-pull-policy-ifnp bats-pull-policy-build bats-healthcheck-wait; do
+  for project in bats-pre-stop bats-post-stop bats-both bats-sync bats-shebang-sh bats-shebang-bash bats-shebang-dash bats-shebang-python3 bats-shebang-default bats-exited-cleanup bats-pre-stop-hooks bats-post-start-hooks bats-multi-file bats-env-file bats-pull-policy bats-pull-policy-ifnp bats-pull-policy-build bats-healthcheck-wait bats-wait-after-healthy; do
     docker compose -p "$project" down --remove-orphans --timeout 5 2>/dev/null || true
   done
 
@@ -632,6 +632,33 @@ teardown() {
 
   # Verify the container is running
   run docker ps --filter "label=com.docker.compose.project=bats-healthcheck-wait" --filter "status=running" -q
+  echo "running containers: $output"
+  assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+}
+
+@test "x-wait-after-healthy delays after container becomes healthy" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/wait-after-healthy"
+
+  # Record start time
+  start_time=$(date +%s)
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-wait-after-healthy web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Record end time
+  end_time=$(date +%s)
+  elapsed=$((end_time - start_time))
+
+  # The deploy should take at least 3 seconds due to x-wait-after-healthy
+  # (we check >= 2 to allow for timing variance)
+  if [[ "$elapsed" -lt 2 ]]; then
+    flunk "expected deploy to take at least 2s due to x-wait-after-healthy, took ${elapsed}s"
+  fi
+
+  # Verify the container is running
+  run docker ps --filter "label=com.docker.compose.project=bats-wait-after-healthy" --filter "status=running" -q
   echo "running containers: $output"
   assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
 }

--- a/tests/fixtures/wait-after-healthy/docker-compose.yaml
+++ b/tests/fixtures/wait-after-healthy/docker-compose.yaml
@@ -1,0 +1,11 @@
+---
+services:
+  web:
+    image: nginx:latest
+    deploy:
+      replicas: 1
+      update_config:
+        order: start-first
+        delay: 0s
+        monitor: 5s
+        x-wait-after-healthy: "3s"


### PR DESCRIPTION
## Summary

- Adds `x-wait-after-healthy` property in `deploy.update_config` extensions that adds a configurable delay after a container becomes healthy before proceeding (e.g., stopping the old container during rolling updates)
- Gives reverse proxies (Traefik, nginx-proxy) time to detect new containers and update routing before old containers are removed
- Applies regardless of whether a Docker healthcheck is defined — fires after all healthcheck validation passes (including `x-healthcheck-host-command`)

Closes #56