### PR TITLE
fix: ensure detached hooks are properly forked before process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ x-pre-deploy-host-command-detached: true
 x-post-deploy-host-command-detached: true
 ```
 
+- Detached commands are guaranteed to be started (forked) before the deploy command returns
 - Detached commands run in the background and do not block deployment
 - Detached commands continue running even if `docker-orchestrate` exits
 - Only boolean values (`true` or `false`) are allowed
@@ -657,6 +658,7 @@ services:
         x-post-stop-host-command-detached: true
 ```
 
+- Detached commands are guaranteed to be started (forked) before the deploy command returns
 - Detached commands run in the background and do not block deployment
 - Detached commands continue running even if `docker-orchestrate` exits or is interrupted
 - Only boolean values (`true` or `false`) are allowed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/dokku/docker-orchestrate
 go 1.25.0
 
 require (
-	github.com/alexellis/go-execute/v2 v2.2.1
 	github.com/compose-spec/compose-go/v2 v2.10.2
 	github.com/docker/compose/v5 v5.1.1
 	github.com/docker/docker v28.5.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxz
 github.com/Microsoft/hcsshim v0.14.0-rc.1/go.mod h1:hTKFGbnDtQb1wHiOWv4v0eN+7boSWAHyK/tNAaYZL0c=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/alexellis/go-execute/v2 v2.2.1 h1:4Ye3jiCKQarstODOEmqDSRCqxMHLkC92Bhse743RdOI=
-github.com/alexellis/go-execute/v2 v2.2.1/go.mod h1:FMdRnUTiFAmYXcv23txrp3VYZfLo24nMpiIneWgKHTQ=
 github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9dedlWa0OhD30=
 github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -3281,7 +3281,7 @@ func TestDeployServicePreDeployHostCommand(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				operationOrder = append(operationOrder, "pre-deploy-script")
 			} else {
 				operationOrder = append(operationOrder, "docker-compose")
@@ -3334,7 +3334,7 @@ func TestDeployServicePreDeployHostCommand(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				return ExecCommandResponse{ExitCode: 1}, fmt.Errorf("exit status 1")
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil
@@ -3394,7 +3394,7 @@ func TestDeployServicePostDeployHostCommand(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				postDeployRan = true
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil
@@ -3445,7 +3445,7 @@ func TestDeployServicePostDeployHostCommand(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				postDeployRan = true
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil
@@ -3497,7 +3497,7 @@ func TestDeployOneShotServiceDeployHooks(t *testing.T) {
 		var scriptCount int
 		mockClient := &mockDockerClient{}
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				scriptCount++
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil
@@ -3541,7 +3541,7 @@ func TestDeployOneShotServiceDeployHooks(t *testing.T) {
 		var scriptCount int
 		mockClient := &mockDockerClient{}
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				scriptCount++
 				return ExecCommandResponse{ExitCode: 0}, nil
 			}
@@ -3603,7 +3603,7 @@ func TestDeployProjectDeployHooks(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				operationOrder = append(operationOrder, "script")
 			} else {
 				operationOrder = append(operationOrder, "docker-compose")
@@ -3658,7 +3658,7 @@ func TestDeployProjectDeployHooks(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				return ExecCommandResponse{ExitCode: 1}, fmt.Errorf("exit status 1")
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil
@@ -3708,7 +3708,7 @@ func TestDeployProjectDeployHooks(t *testing.T) {
 		}
 
 		mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			if strings.HasSuffix(input.Command, ".script") {
+			if len(input.Args) > 0 && input.Args[0] == "-c" {
 				scriptCount++
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil

--- a/internal/exec.go
+++ b/internal/exec.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,9 +11,6 @@ import (
 	"strings"
 	"syscall"
 
-	"context"
-
-	execute "github.com/alexellis/go-execute/v2"
 	"github.com/fatih/color"
 )
 
@@ -54,6 +52,12 @@ type ExecCommandInput struct {
 
 	// WorkingDirectory is the working directory to run the command in
 	WorkingDirectory string
+
+	// Detached starts the command and returns immediately without waiting
+	// for it to complete. The process is forked synchronously (guaranteed
+	// to be running when the function returns) but runs independently
+	// in the background.
+	Detached bool
 }
 
 // ExecCommandResponse is the response for the ExecCommand function
@@ -128,11 +132,12 @@ func ExecCommand(ctx context.Context, input ExecCommandInput) (ExecCommandRespon
 		command = "sudo"
 	}
 
-	cmd := execute.ExecTask{
+	cmd := ExecTask{
 		Command:            command,
 		Args:               commandArgs,
 		Env:                env,
 		DisableStdioBuffer: input.DisableStdioBuffer,
+		Detached:           input.Detached,
 	}
 
 	if input.WorkingDirectory != "" {

--- a/internal/exec_test.go
+++ b/internal/exec_test.go
@@ -2,8 +2,11 @@ package internal
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExecCommandResponse(t *testing.T) {
@@ -72,6 +75,70 @@ func TestExecCommand(t *testing.T) {
 		}
 		if resp.StdoutContents() != "/" {
 			t.Errorf("expected '/', got '%s'", resp.StdoutContents())
+		}
+	})
+
+	t.Run("detached command starts and returns immediately", func(t *testing.T) {
+		start := time.Now()
+		_, err := ExecCommand(ctx, ExecCommandInput{
+			Command:  "sleep",
+			Args:     []string{"10"},
+			Detached: true,
+		})
+		duration := time.Since(start)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should return almost immediately, not wait for the 10s sleep
+		if duration > 2*time.Second {
+			t.Errorf("detached command should return immediately, took %v", duration)
+		}
+	})
+
+	t.Run("detached command actually executes", func(t *testing.T) {
+		markerFile := fmt.Sprintf("/tmp/exec-test-detached-%d", time.Now().UnixNano())
+		defer os.Remove(markerFile)
+
+		_, err := ExecCommand(ctx, ExecCommandInput{
+			Command:  "/bin/sh",
+			Args:     []string{"-c", fmt.Sprintf("touch %s", markerFile)},
+			Detached: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Give the detached process a moment to execute
+		time.Sleep(500 * time.Millisecond)
+
+		if _, err := os.Stat(markerFile); os.IsNotExist(err) {
+			t.Error("expected marker file to exist, detached command did not execute")
+		}
+	})
+
+	t.Run("detached command survives context cancellation", func(t *testing.T) {
+		markerFile := fmt.Sprintf("/tmp/exec-test-ctx-%d", time.Now().UnixNano())
+		defer os.Remove(markerFile)
+
+		// Use a background context for detached (simulating what scripts.go does)
+		bgCtx := context.Background()
+
+		_, err := ExecCommand(bgCtx, ExecCommandInput{
+			Command:  "/bin/sh",
+			Args:     []string{"-c", fmt.Sprintf("sleep 1 && touch %s", markerFile)},
+			Detached: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Wait for the script to complete
+		time.Sleep(2 * time.Second)
+
+		if _, err := os.Stat(markerFile); os.IsNotExist(err) {
+			t.Error("expected marker file to exist, detached command should survive")
 		}
 	})
 }

--- a/internal/execute.go
+++ b/internal/execute.go
@@ -1,0 +1,199 @@
+package internal
+
+// This file is a vendored and modified version of github.com/alexellis/go-execute/v2
+// Original license: MIT
+// Modifications: Added Detached mode support for synchronous process forking
+// with asynchronous wait.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ExecTask describes a command to execute
+type ExecTask struct {
+	// Command is the command to execute.
+	//
+	// Any arguments must be given via Args
+	Command string
+
+	// Args are the arguments to pass to the command.
+	Args []string
+
+	// Shell run the command in a bash shell.
+	// Note that the system must have `bash` installed in the PATH or in /bin/bash
+	Shell bool
+
+	// Env is a list of environment variables to add to the current environment,
+	// these are used to override any existing environment variables.
+	Env []string
+
+	// Cwd is the working directory for the command
+	Cwd string
+
+	// Stdin connect a reader to stdin for the command
+	// being executed.
+	Stdin io.Reader
+
+	// PrintCommand prints the command before executing
+	PrintCommand bool
+
+	// StreamStdio prints stdout and stderr directly to os.Stdout/err as
+	// the command runs.
+	StreamStdio bool
+
+	// DisableStdioBuffer prevents any output from being saved in the
+	// ExecResult, which is useful for when the result is very large, or
+	// when you want to stream the output to another writer exclusively.
+	DisableStdioBuffer bool
+
+	// StdOutWriter when set will receive a copy of stdout from the command
+	StdOutWriter io.Writer
+
+	// StdErrWriter when set will receive a copy of stderr from the command
+	StdErrWriter io.Writer
+
+	// Detached starts the command synchronously (ensuring the OS process is
+	// forked) but does not wait for it to complete. The process runs
+	// independently in the background. A goroutine is spawned to reap
+	// the child process via Wait.
+	Detached bool
+}
+
+// ExecResult contains the result of executing a command
+type ExecResult struct {
+	Stdout    string
+	Stderr    string
+	ExitCode  int
+	Cancelled bool
+}
+
+// Execute runs the command described by the ExecTask and returns the result
+func (et ExecTask) Execute(ctx context.Context) (ExecResult, error) {
+	argsSt := ""
+	if len(et.Args) > 0 {
+		argsSt = strings.Join(et.Args, " ")
+	}
+
+	if et.PrintCommand {
+		fmt.Println("exec: ", et.Command, argsSt)
+	}
+
+	// don't try to run if the context is already cancelled
+	if ctx.Err() != nil {
+		return ExecResult{
+			// the exec package returns -1 for cancelled commands
+			ExitCode:  -1,
+			Cancelled: ctx.Err() == context.Canceled,
+		}, ctx.Err()
+	}
+
+	var command string
+	var commandArgs []string
+	if et.Shell {
+		// On a NixOS system, /bin/bash doesn't exist at /bin/bash
+		// the default behavior of exec.Command is to look for the
+		// executable in PATH.
+		command = "bash"
+		// There is a chance that PATH is not populated or propagated, therefore
+		// when bash cannot be resolved, set it to /bin/bash instead.
+		if _, err := exec.LookPath(command); err != nil {
+			command = "/bin/bash"
+		}
+
+		if len(et.Args) == 0 {
+			startArgs := strings.Split(et.Command, " ")
+			script := strings.Join(startArgs, " ")
+			commandArgs = append([]string{"-c"}, script)
+		} else {
+			script := strings.Join(et.Args, " ")
+			commandArgs = append([]string{"-c"}, fmt.Sprintf("%s %s", et.Command, script))
+		}
+	} else {
+		command = et.Command
+		commandArgs = et.Args
+	}
+
+	cmd := exec.CommandContext(ctx, command, commandArgs...)
+	cmd.Dir = et.Cwd
+
+	if len(et.Env) > 0 {
+		overrides := map[string]bool{}
+		for _, env := range et.Env {
+			key := strings.Split(env, "=")[0]
+			overrides[key] = true
+			cmd.Env = append(cmd.Env, env)
+		}
+
+		for _, env := range os.Environ() {
+			key := strings.Split(env, "=")[0]
+
+			if _, ok := overrides[key]; !ok {
+				cmd.Env = append(cmd.Env, env)
+			}
+		}
+	}
+	if et.Stdin != nil {
+		cmd.Stdin = et.Stdin
+	}
+
+	stdoutBuff := bytes.Buffer{}
+	stderrBuff := bytes.Buffer{}
+
+	var stdoutWriters []io.Writer
+	var stderrWriters []io.Writer
+
+	if !et.DisableStdioBuffer {
+		stdoutWriters = append(stdoutWriters, &stdoutBuff)
+		stderrWriters = append(stderrWriters, &stderrBuff)
+	}
+
+	if et.StreamStdio {
+		stdoutWriters = append(stdoutWriters, os.Stdout)
+		stderrWriters = append(stderrWriters, os.Stderr)
+	}
+
+	if et.StdOutWriter != nil {
+		stdoutWriters = append(stdoutWriters, et.StdOutWriter)
+	}
+	if et.StdErrWriter != nil {
+		stderrWriters = append(stderrWriters, et.StdErrWriter)
+	}
+
+	cmd.Stdout = io.MultiWriter(stdoutWriters...)
+	cmd.Stderr = io.MultiWriter(stderrWriters...)
+
+	startErr := cmd.Start()
+	if startErr != nil {
+		return ExecResult{}, startErr
+	}
+
+	// In detached mode, the process has been forked (Start succeeded).
+	// Spawn a goroutine to reap the child and return immediately.
+	if et.Detached {
+		go func() {
+			_ = cmd.Wait()
+		}()
+		return ExecResult{}, nil
+	}
+
+	exitCode := 0
+	execErr := cmd.Wait()
+	if execErr != nil {
+		if exitError, ok := execErr.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return ExecResult{
+		Stdout:    stdoutBuff.String(),
+		Stderr:    stderrBuff.String(),
+		ExitCode:  exitCode,
+		Cancelled: ctx.Err() == context.Canceled,
+	}, ctx.Err()
+}

--- a/internal/scripts.go
+++ b/internal/scripts.go
@@ -188,67 +188,68 @@ func runHostScript(ctx context.Context, input runScriptInput) error {
 	}
 
 	command := commandBuf.String()
-	if input.Shebang == "" {
-		input.Shebang = "#!/bin/sh"
-	}
-	if !strings.HasPrefix(command, "#!") {
-		command = input.Shebang + "\n" + command
+
+	// Determine interpreter from shebang
+	shebangArgs := parseShebang(command)
+	if shebangArgs == nil {
+		defaultShebang := input.Shebang
+		if defaultShebang == "" {
+			defaultShebang = "#!/bin/sh"
+		}
+		shebangArgs = parseShebang(defaultShebang)
 	}
 
-	tempFile, err := os.CreateTemp("", input.ScriptType+"-*.script")
-	if err != nil {
-		return fmt.Errorf("error creating temporary %s script: %v", input.ScriptType, err)
-	}
-	tempFileName := tempFile.Name()
-
-	if _, err := tempFile.WriteString(command); err != nil {
-		os.Remove(tempFileName)
-		return fmt.Errorf("error writing %s command to temporary file: %v", input.ScriptType, err)
-	}
-	if err := tempFile.Close(); err != nil {
-		os.Remove(tempFileName)
-		return fmt.Errorf("error closing temporary %s file: %v", input.ScriptType, err)
+	// Strip shebang line from script content
+	scriptContent := command
+	if strings.HasPrefix(strings.TrimSpace(scriptContent), "#!") {
+		lines := strings.Split(scriptContent, "\n")
+		if len(lines) > 1 {
+			scriptContent = strings.Join(lines[1:], "\n")
+		} else {
+			scriptContent = ""
+		}
 	}
 
-	if err := os.Chmod(tempFileName, 0755); err != nil {
-		os.Remove(tempFileName)
-		return fmt.Errorf("error making temporary %s script executable: %v", input.ScriptType, err)
-	}
-
-	// If detached, run the command asynchronously and return immediately
-	if input.Detached {
-		go func() {
-			// Use background context so the command continues even if the original context is cancelled
-			bgCtx := context.Background()
-			var output bytes.Buffer
-			_, err := input.Executor(bgCtx, ExecCommandInput{
-				Command:          tempFileName,
-				Env:              input.Env,
-				StdoutWriter:     &output,
-				StderrWriter:     &output,
-				WorkingDirectory: os.TempDir(),
-			})
-			// In detached mode, we don't report errors - the command runs independently
-			_ = err
-			// Clean up the temp file after the command completes
-			os.Remove(tempFileName)
-		}()
-		return nil
-	}
-
-	// Synchronous execution (default behavior) - clean up temp file when done
-	defer os.Remove(tempFileName)
-
-	// Synchronous execution (default behavior)
-	var output bytes.Buffer
-	_, err = input.Executor(ctx, ExecCommandInput{
-		Command:          tempFile.Name(),
+	// Build executor input
+	execInput := ExecCommandInput{
 		Env:              input.Env,
-		StdoutWriter:     &output,
-		StderrWriter:     &output,
+		Detached:         input.Detached,
 		WorkingDirectory: os.TempDir(),
-	})
+	}
+
+	// Shell interpreters: use -c flag; non-shell: use stdin
+	if len(shebangArgs) >= 2 && shebangArgs[len(shebangArgs)-1] == "-c" {
+		execInput.Command = shebangArgs[0]
+		execInput.Args = append(shebangArgs[1:], scriptContent)
+	} else if len(shebangArgs) > 0 {
+		execInput.Command = shebangArgs[0]
+		execInput.Args = shebangArgs[1:]
+		execInput.Stdin = strings.NewReader(scriptContent)
+	} else {
+		// Fallback: use /bin/sh -c
+		execInput.Command = "/bin/sh"
+		execInput.Args = []string{"-c", scriptContent}
+	}
+
+	// For detached mode, use background context so the command continues
+	// even if the caller's context is cancelled. The Detached flag in
+	// ExecCommandInput ensures the process is forked synchronously but
+	// not waited on.
+	if input.Detached {
+		ctx = context.Background()
+	}
+
+	var output bytes.Buffer
+	execInput.StdoutWriter = &output
+	execInput.StderrWriter = &output
+
+	_, err = input.Executor(ctx, execInput)
 	if err != nil {
+		// In detached mode, start errors are genuine failures (process never forked)
+		if input.Detached {
+			return fmt.Errorf("error starting detached %s command: %v", input.ScriptType, err)
+		}
+
 		return &ErrorWithOutput{
 			Err:    fmt.Errorf("%s command failed for container %s: %v", input.ScriptType, containerShortID, err),
 			Output: strings.TrimSpace(output.String()),

--- a/internal/scripts_test.go
+++ b/internal/scripts_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -61,8 +60,9 @@ func TestRunHostScript(t *testing.T) {
 		executorCalled := false
 		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
 			executorCalled = true
-			if !strings.Contains(input.Command, "test-script-") {
-				// The prefix in CreateTemp is input.ScriptType + "-"
+			// Script without shebang defaults to /bin/sh -c
+			if input.Command != "/bin/sh" {
+				return ExecCommandResponse{}, errors.New("expected /bin/sh command")
 			}
 			return ExecCommandResponse{ExitCode: 0}, nil
 		}
@@ -106,10 +106,12 @@ func TestRunHostScript(t *testing.T) {
 			},
 		}
 
-		var executedCommand string
+		var scriptContent string
 		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			content, _ := os.ReadFile(input.Command)
-			executedCommand = string(content)
+			// For shell scripts, the script content is the last arg after -c
+			if len(input.Args) >= 2 && input.Args[0] == "-c" {
+				scriptContent = input.Args[1]
+			}
 			return ExecCommandResponse{ExitCode: 0}, nil
 		}
 
@@ -127,9 +129,9 @@ func TestRunHostScript(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		expected := "#!/bin/sh\necho 12345678901234567890 172.17.0.2 123456789012 web"
-		if !strings.Contains(executedCommand, expected) {
-			t.Errorf("expected command to contain %q, got %q", expected, executedCommand)
+		expected := "echo 12345678901234567890 172.17.0.2 123456789012 web"
+		if !strings.Contains(scriptContent, expected) {
+			t.Errorf("expected script content to contain %q, got %q", expected, scriptContent)
 		}
 	})
 
@@ -148,10 +150,11 @@ func TestRunHostScript(t *testing.T) {
 			},
 		}
 
-		var executedCommand string
+		var scriptContent string
 		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			content, _ := os.ReadFile(input.Command)
-			executedCommand = string(content)
+			if len(input.Args) >= 2 && input.Args[0] == "-c" {
+				scriptContent = input.Args[1]
+			}
 			return ExecCommandResponse{ExitCode: 0}, nil
 		}
 
@@ -170,9 +173,9 @@ func TestRunHostScript(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		expected := "#!/bin/sh\necho myproject web"
-		if !strings.Contains(executedCommand, expected) {
-			t.Errorf("expected command to contain %q, got %q", expected, executedCommand)
+		expected := "echo myproject web"
+		if !strings.Contains(scriptContent, expected) {
+			t.Errorf("expected script content to contain %q, got %q", expected, scriptContent)
 		}
 	})
 
@@ -287,7 +290,7 @@ func TestRunHostScript(t *testing.T) {
 		}
 	})
 
-	t.Run("detached execution", func(t *testing.T) {
+	t.Run("detached execution passes detached flag", func(t *testing.T) {
 		mockClient := &mockDockerClient{
 			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
 				return container.InspectResponse{
@@ -298,11 +301,11 @@ func TestRunHostScript(t *testing.T) {
 			},
 		}
 
-		executorCalled := make(chan bool, 1)
+		var receivedDetached bool
+		executorCalled := false
 		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			executorCalled <- true
-			// Simulate a long-running command
-			time.Sleep(100 * time.Millisecond)
+			executorCalled = true
+			receivedDetached = input.Detached
 			return ExecCommandResponse{ExitCode: 0}, nil
 		}
 
@@ -316,32 +319,21 @@ func TestRunHostScript(t *testing.T) {
 			Detached:    true,
 		}
 
-		start := time.Now()
 		err := runHostScript(ctx, input)
-		duration := time.Since(start)
-
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		// Detached execution should return immediately (much faster than the command duration)
-		if duration > 50*time.Millisecond {
-			t.Errorf("detached execution should return immediately, took %v", duration)
+		if !executorCalled {
+			t.Error("expected executor to be called in detached mode")
 		}
 
-		// Wait a bit to ensure the goroutine has a chance to execute
-		time.Sleep(150 * time.Millisecond)
-
-		// Check that executor was called
-		select {
-		case <-executorCalled:
-			// Good, executor was called
-		default:
-			t.Error("expected executor to be called in detached mode")
+		if !receivedDetached {
+			t.Error("expected executor to receive Detached=true")
 		}
 	})
 
-	t.Run("detached execution with background context", func(t *testing.T) {
+	t.Run("detached execution uses background context", func(t *testing.T) {
 		mockClient := &mockDockerClient{
 			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
 				return container.InspectResponse{
@@ -352,15 +344,14 @@ func TestRunHostScript(t *testing.T) {
 			},
 		}
 
-		executorCtx := make(chan context.Context, 1)
+		var receivedCtx context.Context
 		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-			executorCtx <- ctx
+			receivedCtx = ctx
 			return ExecCommandResponse{ExitCode: 0}, nil
 		}
 
-		// Create a cancellable context
+		// Create a cancellable context and cancel it before calling
 		cancelCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		input := runScriptInput{
 			Client:      mockClient,
@@ -377,25 +368,177 @@ func TestRunHostScript(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		// Cancel the context
+		// Cancel the original context
 		cancel()
 
-		// Wait a bit to ensure the goroutine has a chance to execute
-		time.Sleep(50 * time.Millisecond)
+		// The executor should have received a background context, not the cancelled one
+		if receivedCtx == cancelCtx {
+			t.Error("expected executor to use background context, not the caller's context")
+		}
+		// Background context should not be cancelled
+		if receivedCtx.Err() != nil {
+			t.Errorf("expected background context to not be cancelled, got: %v", receivedCtx.Err())
+		}
+	})
 
-		// Check that executor was called with background context (not the cancelled one)
-		select {
-		case ctx := <-executorCtx:
-			// The context should be background context, not the cancelled one
-			if ctx == cancelCtx {
-				t.Error("expected executor to use background context, not the cancelled context")
+	t.Run("detached execution returns error on start failure", func(t *testing.T) {
+		mockClient := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						HostConfig: &container.HostConfig{NetworkMode: "host"},
+					},
+				}, nil
+			},
+		}
+
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			return ExecCommandResponse{}, errors.New("start failed")
+		}
+
+		input := runScriptInput{
+			Client:      mockClient,
+			ContainerID: "test-container-id",
+			Executor:    executor,
+			ServiceName: "test-service",
+			Script:      "echo hello",
+			ScriptType:  "test-script",
+			Detached:    true,
+		}
+
+		err := runHostScript(ctx, input)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error starting detached") {
+			t.Errorf("expected 'error starting detached' in error, got: %v", err)
+		}
+	})
+
+	t.Run("shell script uses -c flag", func(t *testing.T) {
+		mockClient := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						HostConfig: &container.HostConfig{NetworkMode: "host"},
+					},
+				}, nil
+			},
+		}
+
+		var receivedCommand string
+		var receivedArgs []string
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			receivedCommand = input.Command
+			receivedArgs = input.Args
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		input := runScriptInput{
+			Client:      mockClient,
+			ContainerID: "test-container-id",
+			Executor:    executor,
+			Script:      "#!/bin/bash\necho hello",
+			ScriptType:  "test-script",
+		}
+
+		err := runHostScript(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if receivedCommand != "/bin/bash" {
+			t.Errorf("expected command '/bin/bash', got %q", receivedCommand)
+		}
+		if len(receivedArgs) != 2 || receivedArgs[0] != "-c" {
+			t.Errorf("expected args [-c, <script>], got %v", receivedArgs)
+		}
+		if !strings.Contains(receivedArgs[1], "echo hello") {
+			t.Errorf("expected script content in args, got %q", receivedArgs[1])
+		}
+	})
+
+	t.Run("non-shell script uses stdin", func(t *testing.T) {
+		mockClient := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						HostConfig: &container.HostConfig{NetworkMode: "host"},
+					},
+				}, nil
+			},
+		}
+
+		var receivedCommand string
+		var receivedStdin io.Reader
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			receivedCommand = input.Command
+			receivedStdin = input.Stdin
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		input := runScriptInput{
+			Client:      mockClient,
+			ContainerID: "test-container-id",
+			Executor:    executor,
+			Script:      "#!/usr/bin/python3\nprint('hello')",
+			ScriptType:  "test-script",
+		}
+
+		err := runHostScript(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if receivedCommand != "/usr/bin/python3" {
+			t.Errorf("expected command '/usr/bin/python3', got %q", receivedCommand)
+		}
+		if receivedStdin == nil {
+			t.Fatal("expected stdin to be set for non-shell interpreter")
+		}
+		stdinContent, _ := io.ReadAll(receivedStdin)
+		if !strings.Contains(string(stdinContent), "print('hello')") {
+			t.Errorf("expected stdin to contain script, got %q", string(stdinContent))
+		}
+	})
+
+	t.Run("shebang is stripped from script content", func(t *testing.T) {
+		mockClient := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						HostConfig: &container.HostConfig{NetworkMode: "host"},
+					},
+				}, nil
+			},
+		}
+
+		var scriptContent string
+		executor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+			if len(input.Args) >= 2 && input.Args[0] == "-c" {
+				scriptContent = input.Args[1]
 			}
-			// Background context should not be cancelled
-			if ctx.Err() != nil {
-				t.Errorf("expected background context to not be cancelled, got: %v", ctx.Err())
-			}
-		default:
-			t.Error("expected executor to be called in detached mode")
+			return ExecCommandResponse{ExitCode: 0}, nil
+		}
+
+		input := runScriptInput{
+			Client:      mockClient,
+			ContainerID: "test-container-id",
+			Executor:    executor,
+			Script:      "#!/bin/sh\necho hello\necho world",
+			ScriptType:  "test-script",
+		}
+
+		err := runHostScript(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if strings.Contains(scriptContent, "#!/bin/sh") {
+			t.Errorf("expected shebang to be stripped, got %q", scriptContent)
+		}
+		if !strings.Contains(scriptContent, "echo hello") {
+			t.Errorf("expected script body to be preserved, got %q", scriptContent)
 		}
 	})
 

--- a/test.bats
+++ b/test.bats
@@ -1001,6 +1001,21 @@ teardown() {
   fi
 }
 
+@test "post-deploy host command detached process is forked before exit" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/detached-post-deploy"
+
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-detached-post-deploy-fork web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # The "started" marker must exist — proves the process was forked before exit
+  # This is the key test for issue #80: without the fix, this marker may not
+  # exist because the goroutine that forks the process may not execute before
+  # the main process exits.
+  [ -f /tmp/bats-detached-post-deploy-started ]
+}
+
 # =====================================================
 # Non-detached (synchronous) execution tests
 # =====================================================


### PR DESCRIPTION
## Summary

- Fixes a race condition where detached host commands (especially post-deploy hooks) could silently fail to execute because the Go process exits before the goroutine forking the external process runs
- Vendors the `go-execute` library and adds `Detached` mode support: `cmd.Start()` runs synchronously (guaranteeing the OS process is forked) while `cmd.Wait()` runs in a background goroutine
- Eliminates temporary script files in `runHostScript` — scripts are now passed directly to the interpreter via `-c` flag (shell interpreters) or stdin (non-shell interpreters)
- Adds `Detached` field to `ExecCommandInput`, allowing the executor abstraction to handle the Start/Wait split internally

Closes #80