### PR TITLE
feat: replace unhealthy containers first during rolling updates

### DIFF
--- a/internal/compose.go
+++ b/internal/compose.go
@@ -1204,6 +1204,72 @@ func sortContainersByCreationTime(containers []container.Summary, newestFirst bo
 	})
 }
 
+// containerSortInfo holds the health and restart state for sorting containers
+type containerSortInfo struct {
+	isUnhealthy  bool
+	restartCount int
+}
+
+// sortContainersByHealthThenCreationTime sorts containers by health status (unhealthy first),
+// then by restart count (most restarts first), then by creation time (oldest first).
+// Returns the number of unhealthy containers found.
+func sortContainersByHealthThenCreationTime(ctx context.Context, client DockerClientInterface, containers []container.Summary) int {
+	if len(containers) == 0 {
+		return 0
+	}
+
+	// Inspect each container to get health status and restart count
+	info := make(map[string]containerSortInfo, len(containers))
+	unhealthyCount := 0
+	for _, c := range containers {
+		si := containerSortInfo{}
+		resp, err := client.ContainerInspect(ctx, c.ID)
+		if err == nil && resp.ContainerJSONBase != nil {
+			si.restartCount = resp.RestartCount
+			if resp.ContainerJSONBase.State != nil &&
+				resp.ContainerJSONBase.State.Health != nil &&
+				resp.ContainerJSONBase.State.Health.Status == "unhealthy" {
+				si.isUnhealthy = true
+				unhealthyCount++
+			}
+		}
+		info[c.ID] = si
+	}
+
+	slices.SortFunc(containers, func(a, b container.Summary) int {
+		ai := info[a.ID]
+		bi := info[b.ID]
+
+		// Primary: unhealthy before healthy
+		if ai.isUnhealthy && !bi.isUnhealthy {
+			return -1
+		}
+		if !ai.isUnhealthy && bi.isUnhealthy {
+			return 1
+		}
+
+		// Secondary: more restarts first
+		if ai.restartCount > bi.restartCount {
+			return -1
+		}
+		if ai.restartCount < bi.restartCount {
+			return 1
+		}
+
+		// Tertiary: oldest first
+		if a.Created < b.Created {
+			return -1
+		}
+		if a.Created > b.Created {
+			return 1
+		}
+
+		return 0
+	})
+
+	return unhealthyCount
+}
+
 // ContainerNameTemplateData is the data structure for container name templates
 type ContainerNameTemplateData struct {
 	// ProjectName is the name of the project

--- a/internal/compose_test.go
+++ b/internal/compose_test.go
@@ -2409,3 +2409,417 @@ func TestScaleUpContainersWaitAfterHealthy(t *testing.T) {
 		}
 	})
 }
+
+func TestSortContainersByHealthThenCreationTime(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unhealthy_first_then_oldest", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "healthy_new", Created: 300},
+			{ID: "unhealthy_old", Created: 100},
+			{ID: "healthy_old", Created: 200},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				switch id {
+				case "unhealthy_old":
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: &container.Health{Status: "unhealthy"},
+							},
+						},
+					}, nil
+				default:
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: &container.Health{Status: "healthy"},
+							},
+						},
+					}, nil
+				}
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 1 {
+			t.Errorf("expected 1 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "unhealthy_old" {
+			t.Errorf("expected unhealthy_old first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "healthy_old" {
+			t.Errorf("expected healthy_old second, got %s", containers[1].ID)
+		}
+		if containers[2].ID != "healthy_new" {
+			t.Errorf("expected healthy_new third, got %s", containers[2].ID)
+		}
+	})
+
+	t.Run("all_healthy_falls_back_to_creation_time", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "newest", Created: 300},
+			{ID: "oldest", Created: 100},
+			{ID: "middle", Created: 200},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Health: &container.Health{Status: "healthy"},
+						},
+					},
+				}, nil
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 0 {
+			t.Errorf("expected 0 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "oldest" {
+			t.Errorf("expected oldest first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "middle" {
+			t.Errorf("expected middle second, got %s", containers[1].ID)
+		}
+		if containers[2].ID != "newest" {
+			t.Errorf("expected newest third, got %s", containers[2].ID)
+		}
+	})
+
+	t.Run("all_unhealthy_sorted_by_creation_time", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "newest", Created: 300},
+			{ID: "oldest", Created: 100},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Health: &container.Health{Status: "unhealthy"},
+						},
+					},
+				}, nil
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 2 {
+			t.Errorf("expected 2 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "oldest" {
+			t.Errorf("expected oldest first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "newest" {
+			t.Errorf("expected newest second, got %s", containers[1].ID)
+		}
+	})
+
+	t.Run("no_healthcheck_treated_as_healthy", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "no_healthcheck", Created: 200},
+			{ID: "unhealthy", Created: 100},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				switch id {
+				case "unhealthy":
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: &container.Health{Status: "unhealthy"},
+							},
+						},
+					}, nil
+				default:
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: nil,
+							},
+						},
+					}, nil
+				}
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 1 {
+			t.Errorf("expected 1 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "unhealthy" {
+			t.Errorf("expected unhealthy first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "no_healthcheck" {
+			t.Errorf("expected no_healthcheck second, got %s", containers[1].ID)
+		}
+	})
+
+	t.Run("inspect_error_treated_as_healthy", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "error_container", Created: 200},
+			{ID: "unhealthy", Created: 100},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				switch id {
+				case "unhealthy":
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: &container.Health{Status: "unhealthy"},
+							},
+						},
+					}, nil
+				default:
+					return container.InspectResponse{}, errors.New("inspect failed")
+				}
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 1 {
+			t.Errorf("expected 1 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "unhealthy" {
+			t.Errorf("expected unhealthy first, got %s", containers[0].ID)
+		}
+	})
+
+	t.Run("starting_treated_as_healthy", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "starting_container", Created: 200},
+			{ID: "unhealthy", Created: 100},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				switch id {
+				case "unhealthy":
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: &container.Health{Status: "unhealthy"},
+							},
+						},
+					}, nil
+				default:
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							State: &container.State{
+								Health: &container.Health{Status: "starting"},
+							},
+						},
+					}, nil
+				}
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 1 {
+			t.Errorf("expected 1 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "unhealthy" {
+			t.Errorf("expected unhealthy first, got %s", containers[0].ID)
+		}
+	})
+
+	t.Run("empty_containers", func(t *testing.T) {
+		containers := []container.Summary{}
+		mock := &mockDockerClient{}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 0 {
+			t.Errorf("expected 0 unhealthy, got %d", count)
+		}
+		if len(containers) != 0 {
+			t.Errorf("expected empty slice, got %d", len(containers))
+		}
+	})
+
+	t.Run("single_container", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "only_one", Created: 100},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						State: &container.State{
+							Health: &container.Health{Status: "healthy"},
+						},
+					},
+				}, nil
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 0 {
+			t.Errorf("expected 0 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "only_one" {
+			t.Errorf("expected only_one, got %s", containers[0].ID)
+		}
+	})
+
+	t.Run("healthy_with_different_restart_counts", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "no_restarts", Created: 100},
+			{ID: "many_restarts", Created: 200},
+			{ID: "few_restarts", Created: 150},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				restartCount := 0
+				switch id {
+				case "many_restarts":
+					restartCount = 10
+				case "few_restarts":
+					restartCount = 3
+				}
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						RestartCount: restartCount,
+						State: &container.State{
+							Health: &container.Health{Status: "healthy"},
+						},
+					},
+				}, nil
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 0 {
+			t.Errorf("expected 0 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "many_restarts" {
+			t.Errorf("expected many_restarts first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "few_restarts" {
+			t.Errorf("expected few_restarts second, got %s", containers[1].ID)
+		}
+		if containers[2].ID != "no_restarts" {
+			t.Errorf("expected no_restarts third, got %s", containers[2].ID)
+		}
+	})
+
+	t.Run("unhealthy_with_different_restart_counts", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "unhealthy_few", Created: 100},
+			{ID: "unhealthy_many", Created: 200},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				restartCount := 1
+				if id == "unhealthy_many" {
+					restartCount = 5
+				}
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						RestartCount: restartCount,
+						State: &container.State{
+							Health: &container.Health{Status: "unhealthy"},
+						},
+					},
+				}, nil
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 2 {
+			t.Errorf("expected 2 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "unhealthy_many" {
+			t.Errorf("expected unhealthy_many first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "unhealthy_few" {
+			t.Errorf("expected unhealthy_few second, got %s", containers[1].ID)
+		}
+	})
+
+	t.Run("unhealthy_no_restarts_before_healthy_many_restarts", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "healthy_many_restarts", Created: 100},
+			{ID: "unhealthy_no_restarts", Created: 200},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				switch id {
+				case "unhealthy_no_restarts":
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							RestartCount: 0,
+							State: &container.State{
+								Health: &container.Health{Status: "unhealthy"},
+							},
+						},
+					}, nil
+				default:
+					return container.InspectResponse{
+						ContainerJSONBase: &container.ContainerJSONBase{
+							RestartCount: 10,
+							State: &container.State{
+								Health: &container.Health{Status: "healthy"},
+							},
+						},
+					}, nil
+				}
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 1 {
+			t.Errorf("expected 1 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "unhealthy_no_restarts" {
+			t.Errorf("expected unhealthy_no_restarts first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "healthy_many_restarts" {
+			t.Errorf("expected healthy_many_restarts second, got %s", containers[1].ID)
+		}
+	})
+
+	t.Run("same_restart_count_falls_back_to_oldest", func(t *testing.T) {
+		containers := []container.Summary{
+			{ID: "newer", Created: 200},
+			{ID: "older", Created: 100},
+		}
+
+		mock := &mockDockerClient{
+			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
+				return container.InspectResponse{
+					ContainerJSONBase: &container.ContainerJSONBase{
+						RestartCount: 5,
+						State: &container.State{
+							Health: &container.Health{Status: "healthy"},
+						},
+					},
+				}, nil
+			},
+		}
+
+		count := sortContainersByHealthThenCreationTime(ctx, mock, containers)
+		if count != 0 {
+			t.Errorf("expected 0 unhealthy, got %d", count)
+		}
+		if containers[0].ID != "older" {
+			t.Errorf("expected older first, got %s", containers[0].ID)
+		}
+		if containers[1].ID != "newer" {
+			t.Errorf("expected newer second, got %s", containers[1].ID)
+		}
+	})
+}

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -625,8 +625,11 @@ func DeployService(ctx context.Context, input DeployServiceInput) error {
 		// Only update up to the target replica count
 		containersToUpdate = containersToUpdate[:replicas]
 	}
-	// sort containersToUpdate by oldest first
-	sortContainersByCreationTime(containersToUpdate, false)
+	// sort containersToUpdate by health status (unhealthy first), then restart count (most first), then oldest first
+	unhealthyCount := sortContainersByHealthThenCreationTime(ctx, input.Client, containersToUpdate)
+	if unhealthyCount > 0 {
+		input.Logger.Info(fmt.Sprintf("Prioritizing %d unhealthy container(s) for replacement", unhealthyCount))
+	}
 
 	var rollingUpdateOutput RollingUpdateOutput
 	if len(containersToUpdate) > 0 {

--- a/test.bats
+++ b/test.bats
@@ -658,6 +658,57 @@ teardown() {
   assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
 }
 
+@test "unhealthy containers are replaced first during rolling update" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/unhealthy-priority"
+
+  # Initial deploy with 3 replicas
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-unhealthy-priority --force web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Wait for all containers to become healthy
+  sleep 6
+
+  # Verify all 3 containers are healthy
+  healthy_count=0
+  for id in $(docker ps -q --filter "label=com.docker.compose.project=bats-unhealthy-priority" --filter "status=running"); do
+    health=$(docker inspect --format '{{.State.Health.Status}}' "$id")
+    if [[ "$health" == "healthy" ]]; then
+      healthy_count=$((healthy_count + 1))
+    fi
+  done
+  assert_equal "3" "$healthy_count"
+
+  # Pick one container and make it unhealthy
+  unhealthy_id=$(docker ps -q --filter "label=com.docker.compose.project=bats-unhealthy-priority" --filter "status=running" | head -1)
+  docker exec "$unhealthy_id" rm /tmp/healthy
+
+  # Wait for Docker to mark it unhealthy
+  sleep 6
+
+  # Verify it's actually unhealthy
+  health=$(docker inspect --format '{{.State.Health.Status}}' "$unhealthy_id")
+  assert_equal "unhealthy" "$health"
+
+  # Redeploy (rolling update)
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-unhealthy-priority --force web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Verify the output contains the prioritization message
+  assert_output_contains "Prioritizing 1 unhealthy container(s) for replacement"
+
+  # The unhealthy container should have been replaced (no longer running)
+  run docker ps -q --filter "id=$unhealthy_id" --filter "status=running"
+  assert_equal "" "$output"
+
+  # Verify we still have 3 running containers
+  count=$(docker ps -q --filter "label=com.docker.compose.project=bats-unhealthy-priority" --filter "status=running" | wc -l | tr -d ' ')
+  assert_equal "3" "$count"
+}
+
 @test "one-shot service (restart: no) runs to completion" {
   cd "${BATS_TEST_DIRNAME}/tests/fixtures/one-shot-success"
 

--- a/tests/fixtures/unhealthy-priority/docker-compose.yaml
+++ b/tests/fixtures/unhealthy-priority/docker-compose.yaml
@@ -1,0 +1,17 @@
+---
+services:
+  web:
+    image: nginx:latest
+    command: ["sh", "-c", "touch /tmp/healthy && nginx -g 'daemon off;'"]
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/healthy"]
+      interval: 1s
+      timeout: 2s
+      retries: 3
+      start_period: 1s
+    deploy:
+      replicas: 3
+      update_config:
+        order: start-first
+        delay: 0s
+        monitor: 10s


### PR DESCRIPTION
## Summary

- Sort containers for rolling update replacement by health status (unhealthy first), restart count (most restarts first), then creation time (oldest first)
- Inspect each container's Docker health status and restart count before sorting via `ContainerInspect()`
- Log when unhealthy containers are detected and prioritized for replacement

Closes #60