### PR TITLE
feat: add run subcommands for on-demand one-shot service execution

### DIFF
--- a/commands/run_execute.go
+++ b/commands/run_execute.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/compose-spec/compose-go/v2/dotenv"
+	"github.com/dokku/docker-orchestrate/internal"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// RunExecuteCommand runs a one-shot service on demand
+type RunExecuteCommand struct {
+	command.Meta
+
+	build            bool
+	detach           bool
+	envFiles         []string
+	files            []string
+	profiles         []string
+	projectDirectory string
+	projectName      string
+	pull             string
+}
+
+func (c *RunExecuteCommand) Name() string {
+	return "run execute"
+}
+
+func (c *RunExecuteCommand) Synopsis() string {
+	return "Run a one-shot service on demand"
+}
+
+func (c *RunExecuteCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *RunExecuteCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Run a one-shot service":            fmt.Sprintf("%s %s migrate", appName, c.Name()),
+		"Run a service in detached mode":    fmt.Sprintf("%s %s --detach export", appName, c.Name()),
+		"Build images before running":       fmt.Sprintf("%s %s --build seed", appName, c.Name()),
+		"Run with a specific compose file":  fmt.Sprintf("%s %s -f docker-compose.prod.yaml -p myproject migrate", appName, c.Name()),
+	}
+}
+
+func (c *RunExecuteCommand) Arguments() []command.Argument {
+	return []command.Argument{
+		{
+			Name:        "service-name",
+			Description: "the name of the one-shot service to run",
+			Optional:    false,
+			Type:        command.ArgumentString,
+		},
+	}
+}
+
+func (c *RunExecuteCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *RunExecuteCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *RunExecuteCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.BoolVar(&c.build, "build", false, "build images before running")
+	f.BoolVar(&c.detach, "detach", false, "run the service in the background")
+	f.StringSliceVar(&c.envFiles, "env-file", []string{}, "one or more paths to environment files")
+	f.StringSliceVarP(&c.files, "file", "f", []string{}, "one or more paths to Compose files")
+	f.StringSliceVar(&c.profiles, "profile", []string{}, "one or more profiles to enable")
+	f.StringVar(&c.projectDirectory, "project-directory", "", "the path to the project directory")
+	f.StringVarP(&c.projectName, "project-name", "p", "", "the name of the project")
+	f.StringVar(&c.pull, "pull", "", "pull image policy (always, missing, never)")
+	return f
+}
+
+func (c *RunExecuteCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--build":             complete.PredictNothing,
+			"--detach":            complete.PredictNothing,
+			"--env-file":          complete.PredictFiles("*"),
+			"--file":              complete.PredictFiles("*"),
+			"--profile":           complete.PredictAnything,
+			"--project-directory": complete.PredictDirs("*"),
+			"--project-name":      complete.PredictAnything,
+			"--pull":              complete.PredictSet("always", "missing", "never"),
+		},
+	)
+}
+
+func (c *RunExecuteCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	arguments, err := c.ParsedArguments(flags.Args())
+	if err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	validPullPolicies := []string{"always", "missing", "never"}
+	if c.pull != "" && !slices.Contains(validPullPolicies, c.pull) {
+		c.Ui.Error(fmt.Sprintf("invalid --pull value %q: must be one of: always, missing, never", c.pull))
+		return 1
+	}
+
+	if len(c.files) == 0 {
+		detectedFile, detectErr := internal.ComposeFile()
+		if detectErr != nil {
+			c.Ui.Error(detectErr.Error())
+			return 1
+		}
+		c.files = []string{detectedFile}
+	}
+
+	if c.projectDirectory == "" {
+		c.projectDirectory = filepath.Dir(c.files[0])
+	}
+
+	if c.projectName == "" {
+		c.projectName = filepath.Base(filepath.Dir(c.files[0]))
+	}
+
+	var envVars map[string]string
+	if len(c.envFiles) > 0 {
+		var envErr error
+		envVars, envErr = dotenv.Read(c.envFiles...)
+		if envErr != nil {
+			c.Ui.Error(fmt.Sprintf("error reading env files: %v", envErr))
+			return 1
+		}
+	}
+
+	ctx := context.Background()
+	project, err := internal.ComposeProject(ctx, c.projectName, c.files, c.profiles, c.envFiles)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	client, err := internal.NewDockerClient()
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	logger, ok := c.Ui.(*command.ZerologUi)
+	if !ok {
+		c.Ui.Error("UI is not a ZerologUi")
+		return 1
+	}
+
+	serviceName := arguments["service-name"].StringValue()
+	logger.LogHeader2(fmt.Sprintf("Running one-shot service %s", serviceName))
+	err = internal.RunService(ctx, internal.RunServiceInput{
+		Build:        c.build,
+		Client:       client,
+		ComposeFiles: c.files,
+		Detach:       c.detach,
+		EnvFiles:     c.envFiles,
+		EnvVars:      envVars,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  c.projectName,
+		PullPolicy:   c.pull,
+		ServiceName:  serviceName,
+	})
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if c.detach {
+		logger.Info(fmt.Sprintf("Service %s started in background", serviceName))
+	}
+
+	return 0
+}

--- a/commands/run_list.go
+++ b/commands/run_list.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dokku/docker-orchestrate/internal"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// RunListCommand lists one-shot services available to run
+type RunListCommand struct {
+	command.Meta
+
+	envFiles         []string
+	files            []string
+	profiles         []string
+	projectDirectory string
+	projectName      string
+}
+
+func (c *RunListCommand) Name() string {
+	return "run list"
+}
+
+func (c *RunListCommand) Synopsis() string {
+	return "List one-shot services available to run"
+}
+
+func (c *RunListCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *RunListCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"List one-shot services": fmt.Sprintf("%s %s", appName, c.Name()),
+		"List with a specific compose file": fmt.Sprintf("%s %s -f docker-compose.prod.yaml", appName, c.Name()),
+	}
+}
+
+func (c *RunListCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *RunListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *RunListCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *RunListCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringSliceVar(&c.envFiles, "env-file", []string{}, "one or more paths to environment files")
+	f.StringSliceVarP(&c.files, "file", "f", []string{}, "one or more paths to Compose files")
+	f.StringSliceVar(&c.profiles, "profile", []string{}, "one or more profiles to enable")
+	f.StringVar(&c.projectDirectory, "project-directory", "", "the path to the project directory")
+	f.StringVarP(&c.projectName, "project-name", "p", "", "the name of the project")
+	return f
+}
+
+func (c *RunListCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--env-file":          complete.PredictFiles("*"),
+			"--file":              complete.PredictFiles("*"),
+			"--profile":           complete.PredictAnything,
+			"--project-directory": complete.PredictDirs("*"),
+			"--project-name":      complete.PredictAnything,
+		},
+	)
+}
+
+func (c *RunListCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	if len(c.files) == 0 {
+		detectedFile, detectErr := internal.ComposeFile()
+		if detectErr != nil {
+			c.Ui.Error(detectErr.Error())
+			return 1
+		}
+		c.files = []string{detectedFile}
+	}
+
+	if c.projectDirectory == "" {
+		c.projectDirectory = filepath.Dir(c.files[0])
+	}
+
+	if c.projectName == "" {
+		c.projectName = filepath.Base(filepath.Dir(c.files[0]))
+	}
+
+	ctx := context.Background()
+	project, err := internal.ComposeProject(ctx, c.projectName, c.files, c.profiles, c.envFiles)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	services := internal.ListOneShotServices(project)
+	if len(services) == 0 {
+		c.Ui.Output("No one-shot services found")
+		return 0
+	}
+
+	for _, svc := range services {
+		if svc.Command != "" {
+			c.Ui.Output(fmt.Sprintf("%s\t%s", svc.Name, svc.Command))
+		} else {
+			c.Ui.Output(svc.Name)
+		}
+	}
+
+	return 0
+}

--- a/commands/run_list_executions.go
+++ b/commands/run_list_executions.go
@@ -1,0 +1,109 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/dokku/docker-orchestrate/internal"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// RunListExecutionsCommand lists past and running one-shot service executions
+type RunListExecutionsCommand struct {
+	command.Meta
+
+	projectName string
+}
+
+func (c *RunListExecutionsCommand) Name() string {
+	return "run list-executions"
+}
+
+func (c *RunListExecutionsCommand) Synopsis() string {
+	return "List past and running one-shot service executions"
+}
+
+func (c *RunListExecutionsCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *RunListExecutionsCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"List all executions":               fmt.Sprintf("%s %s", appName, c.Name()),
+		"List executions for a project":     fmt.Sprintf("%s %s -p myproject", appName, c.Name()),
+	}
+}
+
+func (c *RunListExecutionsCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *RunListExecutionsCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *RunListExecutionsCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *RunListExecutionsCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringVarP(&c.projectName, "project-name", "p", "", "filter executions by project name")
+	return f
+}
+
+func (c *RunListExecutionsCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--project-name": complete.PredictAnything,
+		},
+	)
+}
+
+func (c *RunListExecutionsCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	ctx := context.Background()
+	client, err := internal.NewDockerClient()
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	defer client.Close()
+
+	executions, err := internal.ListRunExecutions(ctx, internal.ListRunExecutionsInput{
+		Client:      client,
+		ProjectName: c.projectName,
+	})
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if len(executions) == 0 {
+		c.Ui.Output("No executions found")
+		return 0
+	}
+
+	c.Ui.Output(fmt.Sprintf("%-50s %-20s %-10s %-10s %s", "CONTAINER", "SERVICE", "STATUS", "EXIT CODE", "TRIGGERED AT"))
+	for _, exec := range executions {
+		exitCode := "-"
+		if exec.Status == "exited" {
+			exitCode = fmt.Sprintf("%d", exec.ExitCode)
+		}
+		c.Ui.Output(fmt.Sprintf("%-50s %-20s %-10s %-10s %s", exec.ContainerName, exec.Service, exec.Status, exitCode, exec.TriggeredAt))
+	}
+
+	return 0
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -107,6 +107,78 @@ The `--container-name-template` flag accepts a Go template with these variables:
 
 The default template produces names like `myproject-web-1`, `myproject-web-2`, etc.
 
+## Run
+
+### run list
+
+List one-shot services (`restart: "no"`) available for on-demand execution.
+
+```bash
+docker orchestrate run list [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--env-file` | string (repeatable) | | Path to an environment variable file. Can be specified multiple times. |
+| `-f, --file` | string (repeatable) | `docker-compose.yaml` | Path to a Compose configuration file. Can be specified multiple times. |
+| `--profile` | string (repeatable) | | One or more profiles to enable. |
+| `--project-directory` | string | | Specify an alternate working directory. |
+| `-p, --project-name` | string | directory name | Specify an alternate project name. |
+
+```bash
+docker orchestrate run list
+docker orchestrate run list -f docker-compose.prod.yaml -p myproject
+```
+
+### run execute
+
+Run a one-shot service on demand. The service must have `restart: "no"` set. By default, the service runs in the foreground with stdout and stderr streamed to the terminal. Use `--detach` to run in the background.
+
+```bash
+docker orchestrate run execute <service-name> [flags]
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `service-name` | Yes | The name of the one-shot service to run. |
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--build` | bool | `false` | Build images before running. |
+| `--detach` | bool | `false` | Run the service in the background. |
+| `--env-file` | string (repeatable) | | Path to an environment variable file. Can be specified multiple times. |
+| `-f, --file` | string (repeatable) | `docker-compose.yaml` | Path to a Compose configuration file. Can be specified multiple times. |
+| `--profile` | string (repeatable) | | One or more profiles to enable. |
+| `--project-directory` | string | | Specify an alternate working directory. |
+| `-p, --project-name` | string | directory name | Specify an alternate project name. |
+| `--pull` | string | `missing` | Image pull policy: `always`, `missing`, or `never`. |
+
+```bash
+docker orchestrate run execute migrate
+docker orchestrate run execute seed --build
+docker orchestrate run execute export --detach
+docker orchestrate run execute migrate -f docker-compose.prod.yaml -p myproject
+```
+
+All `run execute` containers are labeled with metadata (`com.dokku.orchestrate/run=true` and project/service/timestamp labels) and persist after exit so they can be queried with `run list-executions`. Per-service [deploy hooks](hooks-and-scripts.md#per-service-deploy-commands) run around the service in foreground mode.
+
+### run list-executions
+
+List past and running one-shot service executions. Queries Docker for containers created by `run execute`.
+
+```bash
+docker orchestrate run list-executions [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-p, --project-name` | string | | Filter executions by project name. When omitted, all projects are shown. |
+
+```bash
+docker orchestrate run list-executions
+docker orchestrate run list-executions -p myproject
+```
+
 ## Cron
 
 ### cron
@@ -222,4 +294,5 @@ docker orchestrate cron uninstall --init systemd --dry-run -p myproject
 - [Cron Scheduling](cron-scheduling.md) -- full cron scheduling documentation
 - [Deployment Configuration](deployment-configuration.md) -- how `update_config` controls rolling updates
 - [Image Management](image-management.md) -- details on `--pull` and `--build` behavior
+- [One-Shot Services](one-shot-services.md) -- one-shot service behavior and manual execution
 - [Skipping Services](skipping-services.md) -- details on `--skip-databases` and other skip mechanisms

--- a/docs/one-shot-services.md
+++ b/docs/one-shot-services.md
@@ -91,8 +91,128 @@ services:
 
 See [Cron Scheduling](cron-scheduling.md) for full documentation on scheduling one-shot services as recurring tasks.
 
+## Manual Execution
+
+One-shot services can be executed on demand using `docker orchestrate run execute`, independent of the deploy pipeline or cron scheduler. This is useful for tasks like seeding a database, generating a one-time report, or running a data export.
+
+### Listing Available Services
+
+Use `run list` to see which one-shot services are defined in your compose file:
+
+```bash
+docker orchestrate run list -f docker-compose.yaml -p myproject
+```
+
+Example output:
+
+```text
+migrate    ./migrate up
+seed       ./seed-data
+export     ./export --format csv
+```
+
+### Running a Service
+
+Use `run execute` to run a one-shot service. The service runs in the foreground by default, with stdout and stderr streamed to the terminal:
+
+```bash
+docker orchestrate run execute seed -f docker-compose.yaml -p myproject
+```
+
+Use `--detach` to run in the background:
+
+```bash
+docker orchestrate run execute export --detach -f docker-compose.yaml -p myproject
+```
+
+Build images before running:
+
+```bash
+docker orchestrate run execute export --build -f docker-compose.yaml -p myproject
+```
+
+### Run-Only Services
+
+Some services should never run during `docker orchestrate deploy` but should be available for manual execution. Combine `restart: "no"` with the `com.dokku.orchestrate/skip` label to create run-only services:
+
+```yaml
+services:
+  db:
+    image: postgres:16
+
+  web:
+    image: myapp:latest
+    depends_on:
+      db:
+        condition: service_healthy
+
+  migrate:
+    image: myapp:latest
+    command: ["./migrate", "up"]
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  seed:
+    image: myapp:latest
+    command: ["./seed-data"]
+    restart: "no"
+    labels:
+      com.dokku.orchestrate/skip: "true"
+
+  export:
+    image: myapp:latest
+    command: ["./export", "--format", "csv"]
+    restart: "no"
+    labels:
+      com.dokku.orchestrate/skip: "true"
+```
+
+In this example:
+
+- `migrate` runs during `docker orchestrate deploy` as a normal one-shot service (before `web`)
+- `seed` and `export` are skipped during deploy (due to the skip label) but can be run manually:
+
+```bash
+docker orchestrate run execute seed -f docker-compose.yaml -p myproject
+docker orchestrate run execute export --detach -f docker-compose.yaml -p myproject
+```
+
+### Manually Triggering Cron Jobs
+
+Cron-scheduled services can also be run on demand. This is useful for testing a cron job or running it outside its normal schedule:
+
+```bash
+docker orchestrate run execute nightly-report -f docker-compose.yaml -p myproject
+```
+
+### Execution History
+
+All `run execute` invocations create labeled containers that persist after exit. Use `run list-executions` to view past and running executions:
+
+```bash
+docker orchestrate run list-executions -p myproject
+```
+
+Example output:
+
+```text
+CONTAINER                                          SERVICE              STATUS     EXIT CODE  TRIGGERED AT
+myproject-seed-20260407-143022-ab3f                 seed                 exited     0          2026-04-07T14:30:22Z
+myproject-export-20260407-150000-cd9e               export               running    -          2026-04-07T15:00:00Z
+```
+
+Containers can be cleaned up with standard Docker commands:
+
+```bash
+docker container prune --filter "label=com.dokku.orchestrate/run=true"
+```
+
 ## See Also
 
+- [Command Reference](command-reference.md#run) -- all run command flags
 - [Cron Scheduling](cron-scheduling.md) -- scheduling one-shot services as recurring cron tasks
 - [Deployment Configuration](deployment-configuration.md) -- deployment order and how one-shot services fit in
 - [Hooks and Scripts](hooks-and-scripts.md) -- per-service deploy commands that also run for one-shot services
+- [Skipping Services](skipping-services.md) -- using the skip label for run-only services

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -1316,12 +1316,18 @@ type DeployOneShotServiceInput struct {
 	Build bool
 	// ComposeFiles is the list of paths to the compose files
 	ComposeFiles []string
+	// ContainerName is the custom container name (empty = docker default)
+	ContainerName string
 	// EnvFiles is the list of paths to the env files
 	EnvFiles []string
 	// Executor is the command executor to use
 	Executor CommandExecutor
+	// Labels is the list of additional labels to attach to the container (e.g. "key=value")
+	Labels []string
 	// Logger is the logger to use
 	Logger *command.ZerologUi
+	// NoRemove when true skips the --rm flag so the container persists after exit
+	NoRemove bool
 	// ProjectName is the name of the project
 	ProjectName string
 	// PullPolicy is the pull policy override from the CLI flag
@@ -1330,10 +1336,12 @@ type DeployOneShotServiceInput struct {
 	Service *types.ServiceConfig
 	// ServiceName is the name of the service
 	ServiceName string
+	// StreamOutput streams stdout and stderr to the terminal
+	StreamOutput bool
 }
 
 // DeployOneShotService runs a one-shot service (restart: "no") to completion.
-// It runs `docker compose run --rm --no-deps <service>`, blocks until exit,
+// It runs `docker compose run [--rm] --no-deps <service>`, blocks until exit,
 // and returns an error on non-zero exit code.
 func DeployOneShotService(ctx context.Context, input DeployOneShotServiceInput) error {
 	pullPolicy, buildImage, err := ResolvePullPolicy(input.PullPolicy, input.Build, input.Service)
@@ -1356,9 +1364,11 @@ func DeployOneShotService(ctx context.Context, input DeployOneShotServiceInput) 
 		buildArgs = append(buildArgs, EnvFileArgs(input.EnvFiles)...)
 		buildArgs = append(buildArgs, "-p", input.ProjectName, "build", input.ServiceName)
 		_, err = executor(ctx, ExecCommandInput{
-			Command:          "docker",
-			Args:             buildArgs,
-			WorkingDirectory: projectDir,
+			Command:            "docker",
+			Args:               buildArgs,
+			WorkingDirectory:   projectDir,
+			StreamStdio:        input.StreamOutput,
+			DisableStdioBuffer: input.StreamOutput,
 		})
 		if err != nil {
 			return fmt.Errorf("error building image for one-shot service %s: %v", input.ServiceName, err)
@@ -1373,9 +1383,11 @@ func DeployOneShotService(ctx context.Context, input DeployOneShotServiceInput) 
 		pullArgs = append(pullArgs, EnvFileArgs(input.EnvFiles)...)
 		pullArgs = append(pullArgs, "-p", input.ProjectName, "pull", input.ServiceName)
 		_, err = executor(ctx, ExecCommandInput{
-			Command:          "docker",
-			Args:             pullArgs,
-			WorkingDirectory: projectDir,
+			Command:            "docker",
+			Args:               pullArgs,
+			WorkingDirectory:   projectDir,
+			StreamStdio:        input.StreamOutput,
+			DisableStdioBuffer: input.StreamOutput,
 		})
 		if err != nil {
 			return fmt.Errorf("error pulling image for one-shot service %s: %v", input.ServiceName, err)
@@ -1387,11 +1399,24 @@ func DeployOneShotService(ctx context.Context, input DeployOneShotServiceInput) 
 	runArgs := []string{"compose"}
 	runArgs = append(runArgs, ComposeFileArgs(input.ComposeFiles)...)
 	runArgs = append(runArgs, EnvFileArgs(input.EnvFiles)...)
-	runArgs = append(runArgs, "-p", input.ProjectName, "run", "--rm", "--no-deps", input.ServiceName)
+	runArgs = append(runArgs, "-p", input.ProjectName, "run")
+	if !input.NoRemove {
+		runArgs = append(runArgs, "--rm")
+	}
+	runArgs = append(runArgs, "--no-deps")
+	if input.ContainerName != "" {
+		runArgs = append(runArgs, "--name", input.ContainerName)
+	}
+	for _, label := range input.Labels {
+		runArgs = append(runArgs, "--label", label)
+	}
+	runArgs = append(runArgs, input.ServiceName)
 	resp, err := executor(ctx, ExecCommandInput{
-		Command:          "docker",
-		Args:             runArgs,
-		WorkingDirectory: projectDir,
+		Command:            "docker",
+		Args:               runArgs,
+		WorkingDirectory:   projectDir,
+		StreamStdio:        input.StreamOutput,
+		DisableStdioBuffer: input.StreamOutput,
 	})
 	if err != nil {
 		return fmt.Errorf("one-shot service %s failed (exit code %d): %v", input.ServiceName, resp.ExitCode, err)

--- a/internal/run.go
+++ b/internal/run.go
@@ -1,0 +1,333 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/josegonzalez/cli-skeleton/command"
+)
+
+// RunServiceInput is the input for the RunService function
+type RunServiceInput struct {
+	// Build is whether to build images before running
+	Build bool
+	// Client is the Docker client
+	Client DockerClientInterface
+	// ComposeFiles is the list of paths to the compose files
+	ComposeFiles []string
+	// Detach runs the service in the background
+	Detach bool
+	// EnvFiles is the list of paths to the env files
+	EnvFiles []string
+	// EnvVars is the parsed environment variables
+	EnvVars map[string]string
+	// Executor is the command executor to use
+	Executor CommandExecutor
+	// Logger is the logger to use
+	Logger *command.ZerologUi
+	// Project is the parsed compose project
+	Project *composetypes.Project
+	// ProjectName is the name of the project
+	ProjectName string
+	// PullPolicy is the pull policy override from the CLI flag
+	PullPolicy string
+	// ServiceName is the name of the service
+	ServiceName string
+}
+
+// RunService runs a one-shot service on demand.
+// It validates the service exists and is a one-shot service, runs deploy hooks,
+// and executes the service with labels for execution tracking.
+func RunService(ctx context.Context, input RunServiceInput) error {
+	if len(input.ComposeFiles) == 0 {
+		return fmt.Errorf("at least one compose file is required")
+	}
+
+	if input.ProjectName == "" {
+		return fmt.Errorf("project name is required")
+	}
+
+	if input.ServiceName == "" {
+		return fmt.Errorf("service name is required")
+	}
+
+	if input.Project == nil {
+		return fmt.Errorf("project is required")
+	}
+
+	var service *composetypes.ServiceConfig
+	for _, s := range input.Project.Services {
+		if s.Name == input.ServiceName {
+			service = &s
+			break
+		}
+	}
+	if service == nil {
+		return fmt.Errorf("service %s not found in compose file", input.ServiceName)
+	}
+
+	if !IsOneShotService(service) {
+		return fmt.Errorf("service %s is not a one-shot service (restart must be \"no\")", input.ServiceName)
+	}
+
+	// Parse per-service deploy hook extensions from deploy config
+	servicePreDeployHostCommand := ""
+	servicePostDeployHostCommand := ""
+	servicePreDeployHostCommandDetached := false
+	servicePostDeployHostCommandDetached := false
+	if service.Deploy != nil && service.Deploy.Extensions != nil {
+		if cmd, ok := service.Deploy.Extensions["x-pre-deploy-host-command"].(string); ok {
+			servicePreDeployHostCommand = cmd
+		}
+		if cmd, ok := service.Deploy.Extensions["x-post-deploy-host-command"].(string); ok {
+			servicePostDeployHostCommand = cmd
+		}
+		if detached, err := parseDetachedFlag(service.Deploy.Extensions, "x-pre-deploy-host-command-detached"); err != nil {
+			return err
+		} else {
+			servicePreDeployHostCommandDetached = detached
+		}
+		if detached, err := parseDetachedFlag(service.Deploy.Extensions, "x-post-deploy-host-command-detached"); err != nil {
+			return err
+		} else {
+			servicePostDeployHostCommandDetached = detached
+		}
+	}
+
+	executor := input.Executor
+	if executor == nil {
+		executor = ExecCommand
+	}
+
+	// Run per-service pre-deploy host command
+	if err := runHostScript(ctx, runScriptInput{
+		Client:      input.Client,
+		Detached:    servicePreDeployHostCommandDetached,
+		Env:         input.EnvVars,
+		Executor:    executor,
+		ProjectName: input.ProjectName,
+		ServiceName: input.ServiceName,
+		Script:      servicePreDeployHostCommand,
+		ScriptType:  "pre-deploy",
+	}); err != nil {
+		return fmt.Errorf("pre-deploy host command failed for service %s: %v", input.ServiceName, err)
+	}
+
+	// Generate container name and labels for execution tracking
+	now := time.Now()
+	suffix := randomSuffix(4)
+	containerName := fmt.Sprintf("%s-%s-%s-%s", input.ProjectName, input.ServiceName, now.Format("20060102-150405"), suffix)
+	triggeredAt := now.UTC().Format(time.RFC3339)
+
+	labels := []string{
+		"com.dokku.orchestrate/run=true",
+		fmt.Sprintf("com.dokku.orchestrate/run-project=%s", input.ProjectName),
+		fmt.Sprintf("com.dokku.orchestrate/run-service=%s", input.ServiceName),
+		fmt.Sprintf("com.dokku.orchestrate/run-triggered-at=%s", triggeredAt),
+	}
+
+	if input.Detach {
+		// Detached mode: build a custom docker compose run command with --detach
+		input.Logger.Info(fmt.Sprintf("Spawning one-shot service %s (container: %s)", input.ServiceName, containerName))
+
+		pullPolicy, buildImage, err := ResolvePullPolicy(input.PullPolicy, input.Build, service)
+		if err != nil {
+			return err
+		}
+
+		projectDir := filepath.Dir(input.ComposeFiles[0])
+
+		// Pre-build image when build flag is set
+		if buildImage {
+			input.Logger.Info(fmt.Sprintf("Building image for one-shot service %s", input.ServiceName))
+			buildArgs := []string{"compose"}
+			buildArgs = append(buildArgs, ComposeFileArgs(input.ComposeFiles)...)
+			buildArgs = append(buildArgs, EnvFileArgs(input.EnvFiles)...)
+			buildArgs = append(buildArgs, "-p", input.ProjectName, "build", input.ServiceName)
+			_, err = executor(ctx, ExecCommandInput{
+				Command:          "docker",
+				Args:             buildArgs,
+				WorkingDirectory: projectDir,
+			})
+			if err != nil {
+				return fmt.Errorf("error building image for one-shot service %s: %v", input.ServiceName, err)
+			}
+		}
+
+		// Pre-pull image when pull policy is "always" and not building
+		if pullPolicy == "always" && !buildImage {
+			input.Logger.Info(fmt.Sprintf("Pulling image for one-shot service %s", input.ServiceName))
+			pullArgs := []string{"compose"}
+			pullArgs = append(pullArgs, ComposeFileArgs(input.ComposeFiles)...)
+			pullArgs = append(pullArgs, EnvFileArgs(input.EnvFiles)...)
+			pullArgs = append(pullArgs, "-p", input.ProjectName, "pull", input.ServiceName)
+			_, err = executor(ctx, ExecCommandInput{
+				Command:          "docker",
+				Args:             pullArgs,
+				WorkingDirectory: projectDir,
+			})
+			if err != nil {
+				return fmt.Errorf("error pulling image for one-shot service %s: %v", input.ServiceName, err)
+			}
+		}
+
+		// Build run command with --detach
+		runArgs := []string{"compose"}
+		runArgs = append(runArgs, ComposeFileArgs(input.ComposeFiles)...)
+		runArgs = append(runArgs, EnvFileArgs(input.EnvFiles)...)
+		runArgs = append(runArgs, "-p", input.ProjectName, "run", "--no-deps")
+		runArgs = append(runArgs, "--name", containerName)
+		for _, label := range labels {
+			runArgs = append(runArgs, "--label", label)
+		}
+		runArgs = append(runArgs, input.ServiceName)
+		runArgs = appendDetachFlag(runArgs)
+
+		_, err = executor(ctx, ExecCommandInput{
+			Command:          "docker",
+			Args:             runArgs,
+			WorkingDirectory: projectDir,
+		})
+		if err != nil {
+			return fmt.Errorf("error spawning one-shot service %s: %v", input.ServiceName, err)
+		}
+
+		return nil
+	}
+
+	// Foreground mode: use DeployOneShotService with streaming and labels
+	err := DeployOneShotService(ctx, DeployOneShotServiceInput{
+		Build:         input.Build,
+		ComposeFiles:  input.ComposeFiles,
+		ContainerName: containerName,
+		EnvFiles:      input.EnvFiles,
+		Executor:      input.Executor,
+		Labels:        labels,
+		Logger:        input.Logger,
+		NoRemove:      true,
+		ProjectName:   input.ProjectName,
+		PullPolicy:    input.PullPolicy,
+		Service:       service,
+		ServiceName:   input.ServiceName,
+		StreamOutput:  true,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Run per-service post-deploy host command (only on success, foreground only)
+	if err := runHostScript(ctx, runScriptInput{
+		Client:      input.Client,
+		Detached:    servicePostDeployHostCommandDetached,
+		Env:         input.EnvVars,
+		Executor:    executor,
+		ProjectName: input.ProjectName,
+		ServiceName: input.ServiceName,
+		Script:      servicePostDeployHostCommand,
+		ScriptType:  "post-deploy",
+	}); err != nil {
+		return fmt.Errorf("post-deploy host command failed for service %s: %v", input.ServiceName, err)
+	}
+
+	return nil
+}
+
+// OneShotServiceInfo contains information about a one-shot service
+type OneShotServiceInfo struct {
+	// Name is the service name
+	Name string
+	// Command is the service command as a string
+	Command string
+}
+
+// ListOneShotServices returns a list of one-shot services in the project
+func ListOneShotServices(project *composetypes.Project) []OneShotServiceInfo {
+	var services []OneShotServiceInfo
+	for _, s := range project.Services {
+		if !IsOneShotService(&s) {
+			continue
+		}
+		cmd := ""
+		if s.Command != nil {
+			cmd = strings.Join(s.Command, " ")
+		}
+		services = append(services, OneShotServiceInfo{
+			Name:    s.Name,
+			Command: cmd,
+		})
+	}
+	return services
+}
+
+// RunExecution contains information about an executed one-shot service
+type RunExecution struct {
+	// ContainerName is the name of the container
+	ContainerName string
+	// Service is the service name
+	Service string
+	// Status is the container status (e.g. "running", "exited")
+	Status string
+	// ExitCode is the exit code (-1 if still running)
+	ExitCode int
+	// TriggeredAt is when the execution was triggered
+	TriggeredAt string
+}
+
+// ListRunExecutionsInput is the input for the ListRunExecutions function
+type ListRunExecutionsInput struct {
+	// Client is the Docker client
+	Client DockerClientInterface
+	// ProjectName filters by project name (empty = all projects)
+	ProjectName string
+}
+
+// ListRunExecutions returns a list of past and running one-shot service executions
+func ListRunExecutions(ctx context.Context, input ListRunExecutionsInput) ([]RunExecution, error) {
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("label", "com.dokku.orchestrate/run=true")
+	if input.ProjectName != "" {
+		filterArgs.Add("label", fmt.Sprintf("com.dokku.orchestrate/run-project=%s", input.ProjectName))
+	}
+
+	containers, err := input.Client.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: filterArgs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing run executions: %v", err)
+	}
+
+	var executions []RunExecution
+	for _, c := range containers {
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+
+		service := c.Labels["com.dokku.orchestrate/run-service"]
+		triggeredAt := c.Labels["com.dokku.orchestrate/run-triggered-at"]
+
+		status := c.State
+		exitCode := -1
+		if c.State == "exited" {
+			// Extract exit code from container status string (e.g. "Exited (0) 5 minutes ago")
+			fmt.Sscanf(c.Status, "Exited (%d)", &exitCode)
+		}
+
+		executions = append(executions, RunExecution{
+			ContainerName: name,
+			Service:       service,
+			Status:        status,
+			ExitCode:      exitCode,
+			TriggeredAt:   triggeredAt,
+		})
+	}
+
+	return executions, nil
+}

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -1,0 +1,752 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/rs/zerolog"
+)
+
+func testLogger() (*command.ZerologUi, *bytes.Buffer) {
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+	return logger, &buf
+}
+
+func TestRunServiceNotFound(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name: "web",
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing service")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected 'not found' in error, got: %s", err.Error())
+	}
+}
+
+func TestRunServiceNotOneShot(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:    "web",
+				Restart: "always",
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "web",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-one-shot service")
+	}
+	if !strings.Contains(err.Error(), "not a one-shot service") {
+		t.Fatalf("expected 'not a one-shot service' in error, got: %s", err.Error())
+	}
+}
+
+func TestRunServiceSuccess(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var executedCommands [][]string
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedCommands = append(executedCommands, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the run command was called
+	found := false
+	for _, args := range executedCommands {
+		argsStr := strings.Join(args, " ")
+		if strings.Contains(argsStr, "run") && strings.Contains(argsStr, "--no-deps") && strings.Contains(argsStr, "migrate") {
+			found = true
+			// Verify --rm is NOT present (NoRemove=true for run)
+			if strings.Contains(argsStr, "--rm") {
+				t.Errorf("expected no --rm flag for run command, got: %s", argsStr)
+			}
+			// Verify labels are present
+			if !strings.Contains(argsStr, "com.dokku.orchestrate/run=true") {
+				t.Errorf("expected run label, got: %s", argsStr)
+			}
+			// Verify --name is present
+			if !strings.Contains(argsStr, "--name") {
+				t.Errorf("expected --name flag, got: %s", argsStr)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected docker compose run command to be executed")
+	}
+}
+
+func TestRunServiceStreamsOutput(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var streamStdioUsed bool
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		argsStr := strings.Join(input.Args, " ")
+		if strings.Contains(argsStr, "run") && strings.Contains(argsStr, "--no-deps") {
+			streamStdioUsed = input.StreamStdio
+		}
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !streamStdioUsed {
+		t.Error("expected StreamStdio to be true for foreground run")
+	}
+}
+
+func TestRunServiceFailure(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		argsStr := strings.Join(input.Args, " ")
+		if strings.Contains(argsStr, "run") {
+			return ExecCommandResponse{ExitCode: 1}, errors.New("exit status 1")
+		}
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err == nil {
+		t.Fatal("expected error for failed service")
+	}
+}
+
+func TestRunServiceDetached(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var executedCommands [][]string
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedCommands = append(executedCommands, input.Args)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"export": types.ServiceConfig{
+				Name:    "export",
+				Restart: "no",
+				Image:   "myapp:latest",
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Detach:       true,
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "export",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify detach flag is present
+	found := false
+	for _, args := range executedCommands {
+		argsStr := strings.Join(args, " ")
+		if strings.Contains(argsStr, "run") && strings.Contains(argsStr, "-d") {
+			found = true
+			// Verify labels are present
+			if !strings.Contains(argsStr, "com.dokku.orchestrate/run=true") {
+				t.Errorf("expected run label in detached mode, got: %s", argsStr)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected docker compose run with -d flag")
+	}
+}
+
+func TestRunServicePreDeployHook(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var executedCommands []string
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedCommands = append(executedCommands, input.Command+" "+strings.Join(input.Args, " "))
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Deploy: &types.DeployConfig{
+					Extensions: map[string]interface{}{
+						"x-pre-deploy-host-command": "echo pre-deploy",
+					},
+				},
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The pre-deploy hook should run before the compose run command
+	if len(executedCommands) < 2 {
+		t.Fatalf("expected at least 2 commands, got %d", len(executedCommands))
+	}
+	// First command should be the hook (run via shell)
+	if !strings.Contains(executedCommands[0], "echo pre-deploy") {
+		t.Errorf("expected first command to be pre-deploy hook, got: %s", executedCommands[0])
+	}
+}
+
+func TestRunServicePostDeployHookOnSuccess(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var executedCommands []string
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		executedCommands = append(executedCommands, input.Command+" "+strings.Join(input.Args, " "))
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Deploy: &types.DeployConfig{
+					Extensions: map[string]interface{}{
+						"x-post-deploy-host-command": "echo post-deploy",
+					},
+				},
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Post-deploy hook should be last
+	lastCmd := executedCommands[len(executedCommands)-1]
+	if !strings.Contains(lastCmd, "echo post-deploy") {
+		t.Errorf("expected last command to be post-deploy hook, got: %s", lastCmd)
+	}
+}
+
+func TestRunServicePostDeployHookSkippedOnFailure(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var executedCommands []string
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		cmd := input.Command + " " + strings.Join(input.Args, " ")
+		executedCommands = append(executedCommands, cmd)
+		if strings.Contains(cmd, "run") && strings.Contains(cmd, "--no-deps") {
+			return ExecCommandResponse{ExitCode: 1}, errors.New("exit status 1")
+		}
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Deploy: &types.DeployConfig{
+					Extensions: map[string]interface{}{
+						"x-post-deploy-host-command": "echo post-deploy",
+					},
+				},
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err == nil {
+		t.Fatal("expected error for failed service")
+	}
+
+	// Post-deploy hook should NOT have run
+	for _, cmd := range executedCommands {
+		if strings.Contains(cmd, "echo post-deploy") {
+			t.Error("post-deploy hook should not run when service fails")
+		}
+	}
+}
+
+func TestRunServicePostDeployHookSkippedOnDetach(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	var executedCommands []string
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		cmd := input.Command + " " + strings.Join(input.Args, " ")
+		executedCommands = append(executedCommands, cmd)
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Deploy: &types.DeployConfig{
+					Extensions: map[string]interface{}{
+						"x-post-deploy-host-command": "echo post-deploy",
+					},
+				},
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Detach:       true,
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "migrate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Post-deploy hook should NOT run in detached mode
+	for _, cmd := range executedCommands {
+		if strings.Contains(cmd, "echo post-deploy") {
+			t.Error("post-deploy hook should not run in detached mode")
+		}
+	}
+}
+
+func TestRunServiceCronServiceRunnable(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"nightly": types.ServiceConfig{
+				Name:    "nightly",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Extensions: map[string]interface{}{
+					"x-cron": map[string]interface{}{
+						"schedule": "0 2 * * *",
+					},
+				},
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "nightly",
+	})
+	if err != nil {
+		t.Fatalf("cron service should be runnable, got error: %v", err)
+	}
+}
+
+func TestRunServiceSkipLabelRunnable(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"seed": types.ServiceConfig{
+				Name:    "seed",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Labels: types.Labels{
+					"com.dokku.orchestrate/skip": "true",
+				},
+			},
+		},
+	}
+
+	err := RunService(context.Background(), RunServiceInput{
+		Client:       mockClient,
+		ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+		Executor:     mockExecutor,
+		Logger:       logger,
+		Project:      project,
+		ProjectName:  "test",
+		ServiceName:  "seed",
+	})
+	if err != nil {
+		t.Fatalf("skip-labeled service should be runnable, got error: %v", err)
+	}
+}
+
+func TestListOneShotServices(t *testing.T) {
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{
+				Name:    "web",
+				Restart: "always",
+				Image:   "myapp:latest",
+			},
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Command: types.ShellCommand{"./migrate", "up"},
+			},
+			"seed": types.ServiceConfig{
+				Name:    "seed",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Command: types.ShellCommand{"./seed-data"},
+			},
+			"worker": types.ServiceConfig{
+				Name:    "worker",
+				Restart: "unless-stopped",
+				Image:   "myapp:latest",
+			},
+		},
+	}
+
+	services := ListOneShotServices(project)
+	if len(services) != 2 {
+		t.Fatalf("expected 2 one-shot services, got %d", len(services))
+	}
+
+	names := make(map[string]bool)
+	for _, svc := range services {
+		names[svc.Name] = true
+	}
+	if !names["migrate"] {
+		t.Error("expected migrate to be listed")
+	}
+	if !names["seed"] {
+		t.Error("expected seed to be listed")
+	}
+	if names["web"] {
+		t.Error("web should not be listed")
+	}
+	if names["worker"] {
+		t.Error("worker should not be listed")
+	}
+}
+
+func TestListOneShotServicesCommand(t *testing.T) {
+	project := &types.Project{
+		Services: types.Services{
+			"migrate": types.ServiceConfig{
+				Name:    "migrate",
+				Restart: "no",
+				Image:   "myapp:latest",
+				Command: types.ShellCommand{"./migrate", "up"},
+			},
+		},
+	}
+
+	services := ListOneShotServices(project)
+	if len(services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(services))
+	}
+	if services[0].Command != "./migrate up" {
+		t.Errorf("expected command './migrate up', got '%s'", services[0].Command)
+	}
+}
+
+func TestListRunExecutions(t *testing.T) {
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			return []container.Summary{
+				{
+					Names: []string{"/test-seed-20260407-143022-ab3f"},
+					State: "exited",
+					Status: "Exited (0) 5 minutes ago",
+					Labels: map[string]string{
+						"com.dokku.orchestrate/run":              "true",
+						"com.dokku.orchestrate/run-project":      "test",
+						"com.dokku.orchestrate/run-service":      "seed",
+						"com.dokku.orchestrate/run-triggered-at": "2026-04-07T14:30:22Z",
+					},
+				},
+				{
+					Names: []string{"/test-export-20260407-150000-cd9e"},
+					State: "running",
+					Labels: map[string]string{
+						"com.dokku.orchestrate/run":              "true",
+						"com.dokku.orchestrate/run-project":      "test",
+						"com.dokku.orchestrate/run-service":      "export",
+						"com.dokku.orchestrate/run-triggered-at": "2026-04-07T15:00:00Z",
+					},
+				},
+			}, nil
+		},
+	}
+
+	executions, err := ListRunExecutions(context.Background(), ListRunExecutionsInput{
+		Client: mockClient,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(executions) != 2 {
+		t.Fatalf("expected 2 executions, got %d", len(executions))
+	}
+
+	// First execution: exited
+	if executions[0].ContainerName != "test-seed-20260407-143022-ab3f" {
+		t.Errorf("expected container name 'test-seed-20260407-143022-ab3f', got '%s'", executions[0].ContainerName)
+	}
+	if executions[0].Service != "seed" {
+		t.Errorf("expected service 'seed', got '%s'", executions[0].Service)
+	}
+	if executions[0].Status != "exited" {
+		t.Errorf("expected status 'exited', got '%s'", executions[0].Status)
+	}
+	if executions[0].ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", executions[0].ExitCode)
+	}
+
+	// Second execution: running
+	if executions[1].Status != "running" {
+		t.Errorf("expected status 'running', got '%s'", executions[1].Status)
+	}
+	if executions[1].ExitCode != -1 {
+		t.Errorf("expected exit code -1 for running, got %d", executions[1].ExitCode)
+	}
+}
+
+func TestListRunExecutionsFilterByProject(t *testing.T) {
+	var capturedFilters string
+	mockClient := &mockDockerClient{
+		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+			// Capture the filter args for verification
+			for _, f := range options.Filters.Get("label") {
+				capturedFilters += f + " "
+			}
+			return []container.Summary{}, nil
+		},
+	}
+
+	_, err := ListRunExecutions(context.Background(), ListRunExecutionsInput{
+		Client:      mockClient,
+		ProjectName: "myproject",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(capturedFilters, "com.dokku.orchestrate/run-project=myproject") {
+		t.Errorf("expected project filter in query, got: %s", capturedFilters)
+	}
+}
+
+func TestRunServiceValidation(t *testing.T) {
+	logger, _ := testLogger()
+	mockClient := &mockDockerClient{}
+	project := &types.Project{
+		Services: types.Services{},
+	}
+
+	tests := []struct {
+		name        string
+		input       RunServiceInput
+		expectedErr string
+	}{
+		{
+			name: "empty compose files",
+			input: RunServiceInput{
+				Client:      mockClient,
+				Logger:      logger,
+				Project:     project,
+				ProjectName: "test",
+				ServiceName: "migrate",
+			},
+			expectedErr: "at least one compose file is required",
+		},
+		{
+			name: "empty project name",
+			input: RunServiceInput{
+				Client:       mockClient,
+				ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+				Logger:       logger,
+				Project:      project,
+				ServiceName:  "migrate",
+			},
+			expectedErr: "project name is required",
+		},
+		{
+			name: "empty service name",
+			input: RunServiceInput{
+				Client:       mockClient,
+				ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+				Logger:       logger,
+				Project:      project,
+				ProjectName:  "test",
+			},
+			expectedErr: "service name is required",
+		},
+		{
+			name: "nil project",
+			input: RunServiceInput{
+				Client:       mockClient,
+				ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+				Logger:       logger,
+				ProjectName:  "test",
+				ServiceName:  "migrate",
+			},
+			expectedErr: "project is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RunService(context.Background(), tt.input)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Errorf("expected error containing %q, got: %s", tt.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,15 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"deploy": func() (cli.Command, error) {
 			return &commands.DeployCommand{Meta: meta}, nil
 		},
+		"run execute": func() (cli.Command, error) {
+			return &commands.RunExecuteCommand{Meta: meta}, nil
+		},
+		"run list": func() (cli.Command, error) {
+			return &commands.RunListCommand{Meta: meta}, nil
+		},
+		"run list-executions": func() (cli.Command, error) {
+			return &commands.RunListExecutionsCommand{Meta: meta}, nil
+		},
 		"docker-cli-plugin-metadata": func() (cli.Command, error) {
 			return &commands.DockerCliPluginMetadataCommand{Meta: meta, Version: Version}, nil
 		},

--- a/test.bats
+++ b/test.bats
@@ -1369,3 +1369,124 @@ teardown() {
   assert_output_contains "Pulling model"
   assert_output_contains "Configuring model"
 }
+
+@test "run execute runs one-shot service successfully" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-success"
+
+  run "$DOCKER_ORCHESTRATE" run execute --project-name bats-run-exec-success migrate
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "One-shot service migrate completed successfully"
+}
+
+@test "run execute rejects non-one-shot service" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-not-one-shot"
+
+  run "$DOCKER_ORCHESTRATE" run execute --project-name bats-run-exec-not-one-shot web
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "not a one-shot service"
+}
+
+@test "run execute rejects unknown service" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-success"
+
+  run "$DOCKER_ORCHESTRATE" run execute --project-name bats-run-exec-unknown nonexistent
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "not found"
+}
+
+@test "run execute labels containers for history" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-success"
+
+  run "$DOCKER_ORCHESTRATE" run execute --project-name bats-run-exec-labels migrate
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # Container should exist (not removed) with run labels
+  run docker ps -a --filter "label=com.dokku.orchestrate/run=true" --filter "label=com.dokku.orchestrate/run-project=bats-run-exec-labels" --filter "label=com.dokku.orchestrate/run-service=migrate" -q
+  echo "labeled containers: $output"
+  [[ -n "$output" ]]
+
+  # Clean up the container
+  docker rm -f $output 2>/dev/null || true
+}
+
+@test "run execute runs deploy hooks" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-with-hooks"
+
+  run "$DOCKER_ORCHESTRATE" run execute --project-name bats-run-exec-hooks migrate
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  [ -f /tmp/orch-run-pre ]
+  [ -f /tmp/orch-run-post ]
+
+  # Clean up labeled container
+  docker rm -f $(docker ps -a --filter "label=com.dokku.orchestrate/run-project=bats-run-exec-hooks" -q) 2>/dev/null || true
+}
+
+@test "run execute --detach returns immediately" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-success"
+
+  run "$DOCKER_ORCHESTRATE" run execute --detach --project-name bats-run-exec-detach migrate
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "started in background"
+
+  # Wait for container to finish
+  sleep 2
+
+  # Clean up labeled container
+  docker rm -f $(docker ps -a --filter "label=com.dokku.orchestrate/run-project=bats-run-exec-detach" -q) 2>/dev/null || true
+}
+
+@test "run list shows one-shot services" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-list"
+
+  run "$DOCKER_ORCHESTRATE" run list --project-name bats-run-list
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "./migrate up"
+  assert_output_contains "./seed-data"
+}
+
+@test "run list excludes long-running services" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-list"
+
+  run "$DOCKER_ORCHESTRATE" run list --project-name bats-run-list
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # web is not a one-shot service and should not appear
+  if echo "$output" | grep -q "^web"; then
+    flunk "web should not be listed as a one-shot service"
+  fi
+}
+
+@test "run list-executions shows executed containers" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-success"
+
+  # First, execute a service to create history
+  "$DOCKER_ORCHESTRATE" run execute --project-name bats-run-exec-history migrate
+
+  # Now list executions
+  run "$DOCKER_ORCHESTRATE" run list-executions --project-name bats-run-exec-history
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "SERVICE"
+  assert_output_contains "exited"
+
+  # Clean up labeled container
+  docker rm -f $(docker ps -a --filter "label=com.dokku.orchestrate/run-project=bats-run-exec-history" -q) 2>/dev/null || true
+}

--- a/tests/fixtures/run-execute-not-one-shot/docker-compose.yaml
+++ b/tests/fixtures/run-execute-not-one-shot/docker-compose.yaml
@@ -1,0 +1,4 @@
+---
+services:
+  web:
+    image: nginx:latest

--- a/tests/fixtures/run-execute-success/docker-compose.yaml
+++ b/tests/fixtures/run-execute-success/docker-compose.yaml
@@ -1,0 +1,6 @@
+---
+services:
+  migrate:
+    image: nginx:latest
+    command: ["echo", "migration-complete"]
+    restart: "no"

--- a/tests/fixtures/run-execute-with-hooks/docker-compose.yaml
+++ b/tests/fixtures/run-execute-with-hooks/docker-compose.yaml
@@ -1,0 +1,11 @@
+---
+services:
+  migrate:
+    image: nginx:latest
+    command: ["echo", "migration-complete"]
+    restart: "no"
+    deploy:
+      x-pre-deploy-host-command: |
+        touch /tmp/orch-run-pre
+      x-post-deploy-host-command: |
+        touch /tmp/orch-run-post

--- a/tests/fixtures/run-list/docker-compose.yaml
+++ b/tests/fixtures/run-list/docker-compose.yaml
@@ -1,0 +1,14 @@
+---
+services:
+  web:
+    image: nginx:latest
+  migrate:
+    image: nginx:latest
+    command: ["./migrate", "up"]
+    restart: "no"
+  seed:
+    image: nginx:latest
+    command: ["./seed-data"]
+    restart: "no"
+    labels:
+      com.dokku.orchestrate/skip: "true"


### PR DESCRIPTION
## Summary

- Adds `run list`, `run execute`, and `run list-executions` subcommands for manually executing one-shot services outside of the deploy pipeline or cron scheduler
- `run execute` streams stdout/stderr to the terminal, supports `--detach` for background execution, and labels containers with metadata for execution history tracking
- Extends `DeployOneShotServiceInput` with `StreamOutput`, `ContainerName`, `Labels`, and `NoRemove` fields (backward compatible with existing deploy callers)