### PR TITLE
ci: drop crazy-max/ghaction-xgo in favor of setup-go + make

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,26 +43,22 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
       - name: Get Repository Name
         id: repo-name
         run: |
           echo "REPOSITORY_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)" >> $GITHUB_OUTPUT
           echo "TARGET_ARCHITECTURE=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT
-          echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_OUTPUT
-      - name: Build binaries
-        uses: crazy-max/ghaction-xgo@v4
-        with:
-          xgo_version: latest
-          go_version: "${{ steps.repo-name.outputs.GO_VERSION }}"
-          dest: dist
-          prefix: ${{ steps.repo-name.outputs.REPOSITORY_NAME }}
-          targets: linux/${{ steps.repo-name.outputs.TARGET_ARCHITECTURE }}
-          v: true
-          x: false
-          race: false
-          ldflags: -s -w -X main.Version=${{ github.ref_name }}
-          buildmode: default
-          trimpath: true
+      - name: Build binary
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          make build/linux/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-${{ steps.repo-name.outputs.TARGET_ARCHITECTURE }}
+          mkdir -p dist
+          cp build/linux/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-${{ steps.repo-name.outputs.TARGET_ARCHITECTURE }} \
+             dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-linux-${{ steps.repo-name.outputs.TARGET_ARCHITECTURE }}
       - name: Check version
         run: |
           "dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-linux-${{ steps.repo-name.outputs.TARGET_ARCHITECTURE }}" --version

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -34,22 +34,25 @@ jobs:
         id: repo-name
         run: |
           echo "REPOSITORY_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)" >> $GITHUB_OUTPUT
-          echo "GO_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_OUTPUT
 
       - name: Build binaries
-        uses: crazy-max/ghaction-xgo@v4
-        with:
-          xgo_version: latest
-          go_version: "${{ steps.repo-name.outputs.GO_VERSION }}"
-          dest: dist
-          prefix: ${{ steps.repo-name.outputs.REPOSITORY_NAME }}
-          targets: darwin/amd64,darwin/arm64,linux/arm64,linux/amd64,windows/amd64
-          v: true
-          x: false
-          race: false
-          ldflags: -s -w -X main.Version=${{ github.ref_name }}
-          buildmode: default
-          trimpath: true
+        env:
+          VERSION: ${{ github.ref_name }}
+          NAME: ${{ steps.repo-name.outputs.REPOSITORY_NAME }}
+        run: |
+          make build/darwin/${NAME}-amd64
+          make build/darwin/${NAME}-arm64
+          make build/linux/${NAME}-amd64
+          make build/linux/${NAME}-arm64
+          make build/windows/${NAME}-amd64.exe
+          make build/windows/${NAME}-arm64.exe
+          mkdir -p dist
+          cp build/darwin/${NAME}-amd64       dist/${NAME}-darwin-amd64
+          cp build/darwin/${NAME}-arm64       dist/${NAME}-darwin-arm64
+          cp build/linux/${NAME}-amd64        dist/${NAME}-linux-amd64
+          cp build/linux/${NAME}-arm64        dist/${NAME}-linux-arm64
+          cp build/windows/${NAME}-amd64.exe  dist/${NAME}-windows-amd64.exe
+          cp build/windows/${NAME}-arm64.exe  dist/${NAME}-windows-arm64.exe
 
       - name: Attest Build Provenance - darwin-amd64
         uses: actions/attest-build-provenance@v4
@@ -60,6 +63,7 @@ jobs:
             dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-linux-amd64
             dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-linux-arm64
             dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-windows-amd64.exe
+            dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-windows-arm64.exe
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -69,11 +73,6 @@ jobs:
 
       - name: Build Debian Packages
         run: |
-          mkdir -p build/linux
-
-          cp dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-linux-amd64 build/linux/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-amd64
-          cp dist/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-linux-arm64 build/linux/${{ steps.repo-name.outputs.REPOSITORY_NAME }}-arm64
-
           bundle exec make build/deb/${{ steps.repo-name.outputs.REPOSITORY_NAME }}_${{ github.ref_name }}_arm64.deb
           bundle exec make build/deb/${{ steps.repo-name.outputs.REPOSITORY_NAME }}_${{ github.ref_name }}_amd64.deb
           cp build/deb/*.deb dist/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifeq ($(CI_BRANCH),release)
 	VERSION ?= $(BASE_VERSION)
 	DOCKER_IMAGE_VERSION = $(VERSION)
 else
-	VERSION = $(shell echo "${BASE_VERSION}")build+$(shell git rev-parse --short HEAD)
+	VERSION ?= $(shell echo "${BASE_VERSION}")build+$(shell git rev-parse --short HEAD)
 	DOCKER_IMAGE_VERSION = $(shell echo "${BASE_VERSION}")build-$(shell git rev-parse --short HEAD)
 endif
 
@@ -70,30 +70,44 @@ $(targets): %-in-docker: .env.docker
 
 build/darwin/$(NAME)-amd64:
 	mkdir -p build/darwin
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -trimpath \
 										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-buildvcs=false \
 										-o build/darwin/$(NAME)-amd64
 
 build/darwin/$(NAME)-arm64:
 	mkdir -p build/darwin
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -trimpath \
 										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-buildvcs=false \
 										-o build/darwin/$(NAME)-arm64
 build/linux/$(NAME)-amd64:
 	mkdir -p build/linux
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -trimpath \
 										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-buildvcs=false \
 										-o build/linux/$(NAME)-amd64
 
 build/linux/$(NAME)-arm64:
 	mkdir -p build/linux
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -trimpath \
 										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-buildvcs=false \
 										-o build/linux/$(NAME)-arm64
+
+build/windows/$(NAME)-amd64.exe:
+	mkdir -p build/windows
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -trimpath \
+										-ldflags "-s -w -X main.Version=$(VERSION)" \
+										-buildvcs=false \
+										-o build/windows/$(NAME)-amd64.exe
+
+build/windows/$(NAME)-arm64.exe:
+	mkdir -p build/windows
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -a -trimpath \
+										-ldflags "-s -w -X main.Version=$(VERSION)" \
+										-buildvcs=false \
+										-o build/windows/$(NAME)-arm64.exe
 
 build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \


### PR DESCRIPTION
## Summary

- `xgo` is a CGO cross-compiler; this project is pure Go, so `xgo` added no value and blocked releases whenever its Docker image lagged upstream Go. The `binary-check` job has been failing with `manifest unknown` because `ghcr.io/crazy-max/xgo` has no image for the Go version in `go.mod` (currently 1.26.2; xgo is on 1.25.1).
- Both workflows now use `actions/setup-go@v6` driven by `go.mod` and call Makefile targets, so cross-compile flags live in one place.
- Replaced the legacy `-asmflags/-gcflags=-trimpath=/src` hack with `-trimpath` in the existing Makefile rules.
- Added `build/windows/$(NAME)-amd64.exe` and `build/windows/$(NAME)-arm64.exe` rules, and included `windows/arm64` in the tagged-release artifacts and attestations.
- Made `VERSION` overridable via env so the workflow can pass `github.ref_name`.