### PR TITLE
feat: improve Docker CLI plugin distribution

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: luizm/action-sh-checker@883217215b11c1fabbf00eb1a9a041f62d74c744
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          SHFMT_OPTS: -l -d -i 2
+          SHFMT_OPTS: -l -d -bn -ci -i 2
         with:
           sh_checker_shellcheck_disable: true
           sh_checker_comment: true

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -79,6 +79,9 @@ jobs:
         env:
           BUNDLE_GEMFILE: .github/Gemfile
 
+      - name: Include install script
+        run: cp install.sh dist/install.sh
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = docker-orchestrate
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+HOST_ARCH = $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 BASE_VERSION ?= 0.0.1
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
@@ -41,9 +42,10 @@ targets = $(addsuffix -in-docker, $(LIST))
 	@echo "VERSION=$(VERSION)" >> .env.docker
 
 install:
-	@$(MAKE) build/$(shell uname -s | tr A-Z a-z)/$(NAME)-arm64
-	mkdir -p ~/.docker/cli-plugins
-	cp build/$(shell uname -s | tr A-Z a-z)/$(NAME)-arm64 ~/.docker/cli-plugins/$(NAME)
+	@$(MAKE) build/$(SYSTEM_NAME)/$(NAME)-$(HOST_ARCH)
+	mkdir -p $(HOME)/.docker/cli-plugins
+	cp build/$(SYSTEM_NAME)/$(NAME)-$(HOST_ARCH) $(HOME)/.docker/cli-plugins/$(NAME)
+	chmod +x $(HOME)/.docker/cli-plugins/$(NAME)
 
 build: prebuild
 	@$(MAKE) build/darwin/$(NAME)-amd64
@@ -129,6 +131,7 @@ build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-amd64=/usr/bin/$(NAME) \
+		build/linux/$(NAME)-amd64=/usr/libexec/docker/cli-plugins/$(NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
@@ -151,6 +154,7 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		--version $(VERSION) \
 		--verbose \
 		build/linux/$(NAME)-arm64=/usr/bin/$(NAME) \
+		build/linux/$(NAME)-arm64=/usr/libexec/docker/cli-plugins/$(NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
 clean:
@@ -183,6 +187,7 @@ release: build bin/gh-release bin/gh-release-body
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_arm64.tgz -C build/darwin $(NAME)-arm64
 	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	cp build/deb/$(NAME)_$(VERSION)_arm64.deb release/$(NAME)_$(VERSION)_arm64.deb
+	cp install.sh release/install.sh
 	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 	bin/gh-release-body $(MAINTAINER)/$(REPOSITORY) v$(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@ A Docker CLI plugin to deploy Docker Compose services with support for rolling u
 
 ## Installation
 
-Build and install as a Docker CLI plugin:
+Install with the quick install script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dokku/docker-orchestrate/main/install.sh | sh
+```
+
+Or via Homebrew:
+
+```bash
+brew install dokku/repo/docker-orchestrate
+```
+
+Or build from source:
 
 ```bash
 make install
 ```
 
-Or download a pre-built binary from [GitHub Releases](https://github.com/dokku/docker-orchestrate/releases) and place it in `~/.docker/cli-plugins/`. See the [Getting Started](docs/getting-started.md#installation) guide for details.
+See the [Getting Started](docs/getting-started.md#installation) guide for all distribution channels (Debian/Ubuntu packages, binary downloads, etc.).
 
 Once installed, the plugin is available via `docker orchestrate`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,15 +8,46 @@ docker-orchestrate fills this gap by reading the `deploy.update_config` section 
 
 ## Installation
 
-### From Source
-
-Build and install as a Docker CLI plugin:
+Once installed, the plugin is available as `docker orchestrate`:
 
 ```bash
-make install
+docker orchestrate version
 ```
 
-This builds the binary and copies it to `~/.docker/cli-plugins/docker-orchestrate`.
+### Quick Install (Linux and macOS)
+
+Use the install script to download the latest release and install it as a Docker CLI plugin:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dokku/docker-orchestrate/main/install.sh | sh
+```
+
+To install a specific version:
+
+```bash
+VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/dokku/docker-orchestrate/main/install.sh | sh
+```
+
+To install to a custom directory:
+
+```bash
+PLUGIN_DIR=/usr/libexec/docker/cli-plugins curl -fsSL https://raw.githubusercontent.com/dokku/docker-orchestrate/main/install.sh | sh
+```
+
+### Homebrew (macOS)
+
+```bash
+brew install dokku/repo/docker-orchestrate
+```
+
+### Debian/Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install docker-orchestrate
+```
+
+The Debian package installs the binary to both `/usr/bin/docker-orchestrate` (for direct invocation) and `/usr/libexec/docker/cli-plugins/docker-orchestrate` (for automatic Docker CLI plugin discovery).
 
 ### Binary Download
 
@@ -28,13 +59,20 @@ cp docker-orchestrate ~/.docker/cli-plugins/docker-orchestrate
 chmod +x ~/.docker/cli-plugins/docker-orchestrate
 ```
 
-### Verify Installation
+Docker looks for plugins in these directories:
 
-Once installed, the plugin is available via `docker orchestrate`:
+- `~/.docker/cli-plugins/` (per-user)
+- `/usr/libexec/docker/cli-plugins/` (system-wide)
+
+### From Source
+
+Build and install as a Docker CLI plugin:
 
 ```bash
-docker orchestrate version
+make install
 ```
+
+This builds the binary for your platform and copies it to `~/.docker/cli-plugins/docker-orchestrate`.
 
 ## Prerequisites
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+# Install docker-orchestrate as a Docker CLI plugin in the
+# current user's ~/.docker/cli-plugins/ directory.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/dokku/docker-orchestrate/main/install.sh | sh
+#   VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/dokku/docker-orchestrate/main/install.sh | sh
+#
+# Environment variables:
+#   VERSION    Release tag to install (defaults to the latest release).
+#   PLUGIN_DIR Override destination directory (defaults to $HOME/.docker/cli-plugins).
+
+set -eu
+
+NAME="docker-orchestrate"
+REPO="dokku/docker-orchestrate"
+PLUGIN_DIR="${PLUGIN_DIR:-${HOME}/.docker/cli-plugins}"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux | darwin) ;;
+  *)
+    echo "error: unsupported OS: $os" >&2
+    exit 1
+    ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "error: unsupported architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "${VERSION:-}" ]; then
+  VERSION="$(
+    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+      | sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' | head -n1
+  )"
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "error: could not determine latest version; set VERSION explicitly" >&2
+  exit 1
+fi
+
+url="https://github.com/${REPO}/releases/download/${VERSION}/${NAME}-${os}-${arch}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+echo "downloading ${url}"
+curl -fsSL "$url" -o "${tmpdir}/${NAME}"
+
+mkdir -p "$PLUGIN_DIR"
+install -m 0755 "${tmpdir}/${NAME}" "${PLUGIN_DIR}/${NAME}"
+
+echo "installed ${NAME} ${VERSION} to ${PLUGIN_DIR}/${NAME}"
+echo "try: docker orchestrate version"

--- a/test.bats
+++ b/test.bats
@@ -1473,6 +1473,70 @@ teardown() {
   fi
 }
 
+# =====================================================
+# Docker CLI plugin tests
+# =====================================================
+
+@test "[plugin] docker-cli-plugin-metadata returns valid JSON" {
+  run "$DOCKER_ORCHESTRATE" docker-cli-plugin-metadata
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "'$DOCKER_ORCHESTRATE' docker-cli-plugin-metadata | jq -r .SchemaVersion"
+  assert_success
+  assert_output "0.1.0"
+
+  run /bin/bash -c "'$DOCKER_ORCHESTRATE' docker-cli-plugin-metadata | jq -e '.Vendor != \"\"'"
+  assert_success
+
+  run /bin/bash -c "'$DOCKER_ORCHESTRATE' docker-cli-plugin-metadata | jq -e '.ShortDescription != \"\"'"
+  assert_success
+}
+
+@test "[plugin] docker-cli-plugin-metadata is hidden from --help" {
+  run /bin/bash -c "'$DOCKER_ORCHESTRATE' --help 2>&1"
+  echo "output: $output"
+  echo "status: $status"
+  [[ "$output" != *"docker-cli-plugin-metadata"* ]] || flunk "expected --help not to list docker-cli-plugin-metadata"
+}
+
+@test "[plugin] docker orchestrate version" {
+  mkdir -p "$HOME/.docker/cli-plugins"
+  cp "$DOCKER_ORCHESTRATE" "$HOME/.docker/cli-plugins/docker-orchestrate"
+  chmod +x "$HOME/.docker/cli-plugins/docker-orchestrate"
+
+  run docker orchestrate version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  [[ -n "$output" ]] || flunk "expected non-empty version output"
+
+  rm -f "$HOME/.docker/cli-plugins/docker-orchestrate"
+}
+
+@test "[plugin] docker orchestrate deploy via Docker CLI" {
+  mkdir -p "$HOME/.docker/cli-plugins"
+  cp "$DOCKER_ORCHESTRATE" "$HOME/.docker/cli-plugins/docker-orchestrate"
+  chmod +x "$HOME/.docker/cli-plugins/docker-orchestrate"
+
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/config-hash-skip"
+
+  run docker orchestrate deploy --project-name bats-plugin-deploy web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  rm -f "$HOME/.docker/cli-plugins/docker-orchestrate"
+}
+
+@test "[plugin] direct invocation without prefix still works" {
+  run "$DOCKER_ORCHESTRATE" version
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "run list-executions shows executed containers" {
   cd "${BATS_TEST_DIRNAME}/tests/fixtures/run-execute-success"
 

--- a/test.bats
+++ b/test.bats
@@ -4,9 +4,9 @@ export SYSTEM_NAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 ARCH="$(uname -m)"
 case "$ARCH" in
-x86_64) ARCH="amd64" ;;
-aarch64) ARCH="arm64" ;;
-arm64) ARCH="arm64" ;;
+  x86_64) ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  arm64) ARCH="arm64" ;;
 esac
 export DOCKER_ORCHESTRATE="${BATS_TEST_DIRNAME}/build/${SYSTEM_NAME}/docker-orchestrate-${ARCH}"
 


### PR DESCRIPTION
## Summary

- Add `install.sh` for quick curl-pipe-sh installation of the plugin binary
- Install binaries to `/usr/libexec/docker/cli-plugins/` in Debian packages for automatic Docker CLI plugin discovery
- Fix architecture detection in Makefile `install` target (was hardcoded to arm64)
- Include `install.sh` in release artifacts
- Add BATS tests for plugin metadata, help hiding, and Docker CLI invocation
- Expand installation documentation with all distribution channels (install script, Homebrew, Debian/Ubuntu, binary download)
- Update SHFMT lint opts to `-bn -ci` for consistency with docker-container-healthchecker