### PR TITLE
feat: add image prune to clean up leftover images

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the [command reference](docs/command-reference.md) for all flags and options
 - [Deployment Configuration](docs/deployment-configuration.md) -- rolling updates, replicas, rollback, and deployment order
 - [Healthchecks](docs/healthchecks.md) -- Docker and script-based health validation
 - [Hooks and Scripts](docs/hooks-and-scripts.md) -- lifecycle hooks, deploy/stop commands, and templating
-- [Image Management](docs/image-management.md) -- pull policy, building images, and volume warnings
+- [Image Management](docs/image-management.md) -- pull policy, building images, cleaning up old images, and volume warnings
 - [One-Shot Services](docs/one-shot-services.md) -- migrations, cache warming, and run-to-completion tasks
 - [Cron Scheduling](docs/cron-scheduling.md) -- scheduling one-shot services as recurring cron tasks
 - [Skipping Services](docs/skipping-services.md) -- excluding databases, labeled services, models, and providers

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -26,6 +26,7 @@ type DeployCommand struct {
 	profiles              []string
 	projectDirectory      string
 	projectName           string
+	pruneImages           bool
 	pull                  string
 	replicas              int
 	skipDatabases         bool
@@ -81,6 +82,7 @@ func (c *DeployCommand) FlagSet() *flag.FlagSet {
 	f.StringSliceVarP(&c.files, "file", "f", []string{}, "one or more paths to Compose files")
 	f.StringVar(&c.projectDirectory, "project-directory", "", "the path to the project directory")
 	f.StringVarP(&c.projectName, "project-name", "p", "", "the name of the project")
+	f.BoolVar(&c.pruneImages, "prune-images", false, "remove images left over from previous builds after deploying")
 	f.StringVar(&c.pull, "pull", "", "pull image policy (always, missing, never)")
 	f.BoolVar(&c.skipDatabases, "skip-databases", false, "whether to skip deploying databases")
 	return f
@@ -98,6 +100,7 @@ func (c *DeployCommand) AutocompleteFlags() complete.Flags {
 			"--profiles":                complete.PredictAnything,
 			"--project-directory":       complete.PredictDirs("*"),
 			"--project-name":            complete.PredictAnything,
+			"--prune-images":            complete.PredictNothing,
 			"--pull":                    complete.PredictSet("always", "missing", "never"),
 			"--replicas":                complete.PredictAnything,
 			"--skip-databases":          complete.PredictNothing,
@@ -192,6 +195,7 @@ func (c *DeployCommand) Run(args []string) int {
 			Logger:                logger,
 			Project:               project,
 			ProjectName:           c.projectName,
+			PruneImages:           c.pruneImages,
 			PullPolicy:            c.pull,
 			SkipDatabases:         c.skipDatabases,
 		})
@@ -224,5 +228,17 @@ func (c *DeployCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
+
+	if c.pruneImages {
+		if _, err := internal.PruneImages(ctx, internal.PruneImagesInput{
+			Client:      client,
+			Logger:      logger,
+			Project:     project,
+			ProjectName: c.projectName,
+		}); err != nil {
+			logger.Warn(fmt.Sprintf("Failed to prune images: %v", err))
+		}
+	}
+
 	return 0
 }

--- a/commands/image_prune.go
+++ b/commands/image_prune.go
@@ -1,0 +1,155 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dokku/docker-orchestrate/internal"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// ImagePruneCommand removes images left over from previous builds of a project
+type ImagePruneCommand struct {
+	command.Meta
+
+	dryRun           bool
+	envFiles         []string
+	files            []string
+	profiles         []string
+	projectDirectory string
+	projectName      string
+}
+
+func (c *ImagePruneCommand) Name() string {
+	return "image prune"
+}
+
+func (c *ImagePruneCommand) Synopsis() string {
+	return "Remove images left over from previous builds of a project"
+}
+
+func (c *ImagePruneCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *ImagePruneCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Prune leftover images for the project": fmt.Sprintf("%s %s", appName, c.Name()),
+		"Preview which images would be pruned":  fmt.Sprintf("%s %s --dry-run", appName, c.Name()),
+		"Prune leftover images for a project":   fmt.Sprintf("%s %s -p myproject", appName, c.Name()),
+	}
+}
+
+func (c *ImagePruneCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *ImagePruneCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ImagePruneCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *ImagePruneCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.BoolVar(&c.dryRun, "dry-run", false, "report which images would be removed without removing them")
+	f.StringSliceVar(&c.envFiles, "env-file", []string{}, "one or more paths to environment files")
+	f.StringSliceVarP(&c.files, "file", "f", []string{}, "one or more paths to Compose files")
+	f.StringSliceVar(&c.profiles, "profile", []string{}, "one or more profiles to enable")
+	f.StringVar(&c.projectDirectory, "project-directory", "", "the path to the project directory")
+	f.StringVarP(&c.projectName, "project-name", "p", "", "the name of the project")
+	return f
+}
+
+func (c *ImagePruneCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--dry-run":           complete.PredictNothing,
+			"--env-file":          complete.PredictFiles("*"),
+			"--file":              complete.PredictFiles("*"),
+			"--profile":           complete.PredictAnything,
+			"--project-directory": complete.PredictDirs("*"),
+			"--project-name":      complete.PredictAnything,
+		},
+	)
+}
+
+func (c *ImagePruneCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	if len(c.files) == 0 {
+		detectedFile, detectErr := internal.ComposeFile()
+		if detectErr != nil {
+			c.Ui.Error(detectErr.Error())
+			return 1
+		}
+		c.files = []string{detectedFile}
+	}
+
+	if c.projectDirectory == "" {
+		c.projectDirectory = filepath.Dir(c.files[0])
+	}
+
+	if c.projectName == "" {
+		c.projectName = filepath.Base(filepath.Dir(c.files[0]))
+	}
+
+	ctx := context.Background()
+	project, err := internal.ComposeProject(ctx, c.projectName, c.files, c.profiles, c.envFiles)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	client, err := internal.NewDockerClient()
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	defer client.Close()
+
+	logger, ok := c.Ui.(*command.ZerologUi)
+	if !ok {
+		c.Ui.Error("UI is not a ZerologUi")
+		return 1
+	}
+
+	pruned, err := internal.PruneImages(ctx, internal.PruneImagesInput{
+		Client:      client,
+		DryRun:      c.dryRun,
+		Logger:      logger,
+		Project:     project,
+		ProjectName: c.projectName,
+	})
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if len(pruned) == 0 {
+		logger.Info("No leftover images found")
+		return 0
+	}
+
+	if c.dryRun {
+		logger.Info(fmt.Sprintf("%d image(s) would be pruned", len(pruned)))
+	} else {
+		logger.Info(fmt.Sprintf("Pruned %d image(s)", len(pruned)))
+	}
+
+	return 0
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Complete documentation for docker-orchestrate, a Docker CLI plugin for deploying
 - [Deployment Configuration](deployment-configuration.md) -- rolling updates, replicas, rollback, and deployment order
 - [Healthchecks](healthchecks.md) -- Docker and script-based health validation
 - [Hooks and Scripts](hooks-and-scripts.md) -- lifecycle hooks, deploy/stop commands, and templating
-- [Image Management](image-management.md) -- pull policy, building images, and volume warnings
+- [Image Management](image-management.md) -- pull policy, building images, cleaning up old images, and volume warnings
 - [Models](models.md) -- deploying services that reference AI models
 - [One-Shot Services](one-shot-services.md) -- migrations, cache warming, and run-to-completion tasks
 - [Cron Scheduling](cron-scheduling.md) -- scheduling one-shot services as recurring cron tasks

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -24,6 +24,7 @@ docker orchestrate deploy [service-name] [flags]
 | `-p, --project-name` | string | directory name | Specify an alternate project name. |
 | `--profile` | string (repeatable) | | One or more profiles to enable. Can be specified multiple times or as a comma-separated list. |
 | `--project-directory` | string | | Specify an alternate working directory. |
+| `--prune-images` | bool | `false` | Remove images left over from previous builds after a successful deploy. See [image management](image-management.md#cleaning-up-old-images). |
 | `--pull` | string | `missing` | Image pull policy: `always`, `missing`, or `never`. See [image management](image-management.md). |
 | `--replicas` | int | from compose file | Override the number of replicas. Requires a `service-name` argument. |
 | `--skip-databases` | bool | `false` | Skip deploying database services. See [skipping services](skipping-services.md#database-services). |
@@ -83,6 +84,12 @@ docker orchestrate deploy --build
 docker orchestrate deploy --build --pull never web
 ```
 
+Build and prune leftover images after deploying:
+
+```bash
+docker orchestrate deploy --build --prune-images
+```
+
 Deploy while skipping database services:
 
 ```bash
@@ -106,6 +113,32 @@ The `--container-name-template` flag accepts a Go template with these variables:
 | `.InstanceID` | The replica instance number |
 
 The default template produces names like `myproject-web-1`, `myproject-web-2`, etc.
+
+## Image
+
+### image prune
+
+Remove images left over from previous builds of a project. Keeps the image currently referenced by each service and removes every other image carrying the project's `com.docker.compose.project` label. Images still in use by a container are skipped. See [image management](image-management.md#cleaning-up-old-images).
+
+```bash
+docker orchestrate image prune [flags]
+```
+
+| Flag | Type | Default | Description |
+| ------ | ------ | --------- | ------------- |
+| `--dry-run` | bool | `false` | Report which images would be removed without removing them. |
+| `--env-file` | string (repeatable) | | Path to an environment variable file for compose file interpolation. Can be specified multiple times. |
+| `-f, --file` | string (repeatable) | `docker-compose.yaml` | Path to a Compose configuration file. Can be specified multiple times. |
+| `--profile` | string (repeatable) | | One or more profiles to enable. |
+| `--project-directory` | string | | Specify an alternate working directory. |
+| `-p, --project-name` | string | directory name | Specify an alternate project name. |
+
+```bash
+docker orchestrate image prune
+docker orchestrate image prune -p myproject
+docker orchestrate image prune --dry-run
+docker orchestrate image prune -f docker-compose.prod.yaml -p myproject
+```
 
 ## Run
 

--- a/docs/image-management.md
+++ b/docs/image-management.md
@@ -61,8 +61,39 @@ services:
 - When building, the pre-pull step is skipped since the image is built locally
 - The `--build` flag also bypasses [config hash comparison](deployment-configuration.md#config-hash-comparison) for services with a `build` section, since the image content may have changed
 
+## Cleaning Up Old Images
+
+Every time a service is built, Docker Compose tags the resulting image (`<project>-<service>` by default, or the service's `image:` value) and records `com.docker.compose.project` and `com.docker.compose.service` labels in the image. When you redeploy, the new build takes over the tag and the previous image is left behind -- either untagged (dangling) or, when the image tag changes between deploys, orphaned under its old tag. Over many redeploys these leftover images accumulate and consume disk space.
+
+The `image prune` command reclaims them:
+
+```bash
+docker orchestrate image prune
+docker orchestrate image prune -p myproject
+docker orchestrate image prune --dry-run
+```
+
+How it works:
+
+- It keeps the image currently referenced by each service in the compose file (including services disabled by an inactive profile).
+- It removes every other image carrying this project's `com.docker.compose.project` label. Because only images built by Compose carry that label, pulled base images and images from other projects are never touched.
+- Images still in use by a container -- for example, an old replica draining during a rolling update -- are skipped rather than force-removed.
+- Pass `--dry-run` to print which images would be removed without removing them.
+
+The command reads the compose file to determine which images are current, so run it with the same `-f`/`-p`/`--profile` options you deploy with.
+
+### Pruning as part of a deploy
+
+Pass `--prune-images` to `deploy` to prune leftover images automatically after a successful deploy:
+
+```bash
+docker orchestrate deploy --build --prune-images
+```
+
+Pruning runs only after the deploy succeeds. A prune failure is logged as a warning and does not fail the deploy.
+
 ## See Also
 
-- [Command Reference](command-reference.md) -- `--pull` and `--build` flag details
+- [Command Reference](command-reference.md) -- `--pull`, `--build`, and `image prune` flag details
 - [Deployment Configuration](deployment-configuration.md) -- how config hash comparison interacts with `--build` and `--pull always`
 - [Volumes](volumes.md) -- anonymous volume warnings during rolling updates

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -44,6 +44,8 @@ type DeployProjectInput struct {
 	Project *types.Project
 	// ProjectName is the name of the project
 	ProjectName string
+	// PruneImages removes images left over from previous builds after deploying
+	PruneImages bool
 	// PullPolicy is the pull policy override from the CLI flag (always, missing, never)
 	PullPolicy string
 	// SkipDatabases is whether to skip deploying databases
@@ -146,6 +148,20 @@ func DeployProject(ctx context.Context, input DeployProjectInput) error {
 		ScriptType:  "project-post-deploy",
 	}); err != nil {
 		return fmt.Errorf("project post-deploy host command failed: %v", err)
+	}
+
+	// Prune images left over from previous builds. This runs after a successful
+	// deploy, so a prune failure is logged as a warning rather than failing the
+	// deploy.
+	if input.PruneImages {
+		if _, err := PruneImages(ctx, PruneImagesInput{
+			Client:      input.Client,
+			Logger:      input.Logger,
+			Project:     input.Project,
+			ProjectName: input.ProjectName,
+		}); err != nil {
+			input.Logger.Warn(fmt.Sprintf("Failed to prune images: %v", err))
+		}
 	}
 
 	return nil

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -3998,6 +3998,89 @@ func TestDeployProjectDeployHooks(t *testing.T) {
 	})
 }
 
+func TestDeployProjectPruneImages(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &command.ZerologUi{
+		StderrLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		StdoutLogger:      zerolog.New(&buf).With().Timestamp().Logger(),
+		OriginalFields:    nil,
+		Ui:                nil,
+		OutputIndentField: false,
+	}
+
+	newMock := func(imageListCalled *bool, removed *[]string) *mockDockerClient {
+		return &mockDockerClient{
+			containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+				return []container.Summary{}, nil
+			},
+			imageList: func(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+				*imageListCalled = true
+				return []image.Summary{{ID: "sha256:leftover"}}, nil
+			},
+			imageRemove: func(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+				*removed = append(*removed, imageID)
+				return []image.DeleteResponse{{Deleted: imageID}}, nil
+			},
+		}
+	}
+
+	mockExecutor := func(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+		return ExecCommandResponse{ExitCode: 0}, nil
+	}
+
+	project := &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{Name: "web"},
+		},
+	}
+
+	t.Run("prunes when PruneImages is true", func(t *testing.T) {
+		imageListCalled := false
+		var removed []string
+		err := DeployProject(context.Background(), DeployProjectInput{
+			Client:       newMock(&imageListCalled, &removed),
+			Executor:     mockExecutor,
+			ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+			Logger:       logger,
+			Project:      project,
+			ProjectName:  "test",
+			PruneImages:  true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !imageListCalled {
+			t.Error("expected image list to be queried when PruneImages is true")
+		}
+		if len(removed) != 1 || removed[0] != "sha256:leftover" {
+			t.Errorf("expected leftover image to be removed, got %v", removed)
+		}
+	})
+
+	t.Run("does not prune when PruneImages is false", func(t *testing.T) {
+		imageListCalled := false
+		var removed []string
+		err := DeployProject(context.Background(), DeployProjectInput{
+			Client:       newMock(&imageListCalled, &removed),
+			Executor:     mockExecutor,
+			ComposeFiles: []string{"/tmp/docker-compose.yaml"},
+			Logger:       logger,
+			Project:      project,
+			ProjectName:  "test",
+			PruneImages:  false,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if imageListCalled {
+			t.Error("expected no image pruning when PruneImages is false")
+		}
+		if len(removed) != 0 {
+			t.Errorf("expected no removals, got %v", removed)
+		}
+	})
+}
+
 func TestEnsureModels(t *testing.T) {
 	var buf bytes.Buffer
 	logger := &command.ZerologUi{

--- a/internal/docker.go
+++ b/internal/docker.go
@@ -22,6 +22,8 @@ type DockerClientInterface interface {
 	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
 	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	ImageInspect(ctx context.Context, imageID string) (image.InspectResponse, error)
+	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
+	ImageRemove(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error)
 	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, containerID, newName string) error
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
@@ -101,6 +103,16 @@ func (d *DockerClient) ContainerTerminate(ctx context.Context, containerID strin
 // ImageInspect inspects an image
 func (d *DockerClient) ImageInspect(ctx context.Context, imageID string) (image.InspectResponse, error) {
 	return d.cli.ImageInspect(ctx, imageID)
+}
+
+// ImageList lists images
+func (d *DockerClient) ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+	return d.cli.ImageList(ctx, options)
+}
+
+// ImageRemove removes an image
+func (d *DockerClient) ImageRemove(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+	return d.cli.ImageRemove(ctx, imageID, options)
 }
 
 // ContainerExecCreate creates an exec instance in a container

--- a/internal/docker_test.go
+++ b/internal/docker_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	dockerClient "github.com/docker/docker/client"
 )
 
@@ -222,6 +224,47 @@ func TestDockerClientImageInspect(t *testing.T) {
 	}
 	if resp.ID != "sha256:deadbeef" {
 		t.Errorf("expected id sha256:deadbeef, got %q", resp.ID)
+	}
+}
+
+func TestDockerClientImageList(t *testing.T) {
+	_, client := newTestDockerWrapper(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/images/json") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("filters"); !strings.Contains(got, "com.docker.compose.project=myproject") {
+			t.Errorf("expected label filter in query, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"Id":"sha256:img1","RepoTags":["myproject-web:latest"]}]`))
+	})
+
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("label", "com.docker.compose.project=myproject")
+	images, err := client.ImageList(context.Background(), image.ListOptions{Filters: filterArgs})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(images) != 1 || images[0].ID != "sha256:img1" {
+		t.Errorf("unexpected images: %+v", images)
+	}
+}
+
+func TestDockerClientImageRemove(t *testing.T) {
+	_, client := newTestDockerWrapper(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.Path, "/images/sha256:img1") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"Deleted":"sha256:img1"}]`))
+	})
+
+	resp, err := client.ImageRemove(context.Background(), "sha256:img1", image.RemoveOptions{PruneChildren: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp) != 1 || resp[0].Deleted != "sha256:img1" {
+		t.Errorf("unexpected delete response: %+v", resp)
 	}
 }
 

--- a/internal/image_prune.go
+++ b/internal/image_prune.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/josegonzalez/cli-skeleton/command"
+)
+
+// PruneImagesInput is the input for the PruneImages function
+type PruneImagesInput struct {
+	// Client is the Docker client
+	Client DockerClientInterface
+	// DryRun reports what would be removed without removing anything
+	DryRun bool
+	// Logger is the logger to use
+	Logger *command.ZerologUi
+	// Project is the parsed compose project
+	Project *composetypes.Project
+	// ProjectName is the name of the project
+	ProjectName string
+}
+
+// PrunedImage describes an image that was (or would be) removed
+type PrunedImage struct {
+	// ID is the image ID
+	ID string
+	// Tags is the list of repo tags for the image (empty for dangling images)
+	Tags []string
+}
+
+// PruneImages removes images left over from previous builds of a compose
+// project. Compose bakes a com.docker.compose.project label into every image it
+// builds, and that label persists even after a rebuild leaves the old image
+// dangling. PruneImages keeps the image currently referenced by each service
+// and removes every other image carrying the project's compose label. Images
+// still in use by a container are skipped rather than force-removed.
+func PruneImages(ctx context.Context, input PruneImagesInput) ([]PrunedImage, error) {
+	if input.ProjectName == "" {
+		return nil, fmt.Errorf("project name is required")
+	}
+
+	if input.Project == nil {
+		return nil, fmt.Errorf("project is required")
+	}
+
+	// Build the set of image IDs currently referenced by a service. Include
+	// profile-disabled services so their images are not removed while a profile
+	// is inactive.
+	keep := map[string]bool{}
+	for _, service := range input.Project.AllServices() {
+		imageName := api.GetImageNameOrDefault(service, input.ProjectName)
+		if imageName == "" {
+			continue
+		}
+		inspect, err := input.Client.ImageInspect(ctx, imageName)
+		if err != nil {
+			continue
+		}
+		keep[inspect.ID] = true
+	}
+
+	// List candidate images built by compose for this project. Only built images
+	// carry the compose project label, so pulled base images and other projects'
+	// images are never considered.
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("label", fmt.Sprintf("com.docker.compose.project=%s", input.ProjectName))
+	images, err := input.Client.ImageList(ctx, image.ListOptions{Filters: filterArgs})
+	if err != nil {
+		return nil, fmt.Errorf("error listing images: %v", err)
+	}
+
+	var pruned []PrunedImage
+	for _, img := range images {
+		if keep[img.ID] {
+			continue
+		}
+
+		label := imageLabel(img)
+		if input.DryRun {
+			input.Logger.Info(fmt.Sprintf("Would remove image %s", label))
+			pruned = append(pruned, PrunedImage{ID: img.ID, Tags: img.RepoTags})
+			continue
+		}
+
+		if _, err := input.Client.ImageRemove(ctx, img.ID, image.RemoveOptions{PruneChildren: true}); err != nil {
+			input.Logger.Warn(fmt.Sprintf("Skipping image %s: %v", label, err))
+			continue
+		}
+
+		input.Logger.Info(fmt.Sprintf("Removed image %s", label))
+		pruned = append(pruned, PrunedImage{ID: img.ID, Tags: img.RepoTags})
+	}
+
+	return pruned, nil
+}
+
+// imageLabel returns a human-readable identifier for an image summary,
+// preferring its first real tag and falling back to a short image ID.
+func imageLabel(img image.Summary) string {
+	for _, tag := range img.RepoTags {
+		if tag != "" && tag != "<none>:<none>" {
+			return tag
+		}
+	}
+	id := strings.TrimPrefix(img.ID, "sha256:")
+	if len(id) > 12 {
+		id = id[:12]
+	}
+	return id
+}

--- a/internal/image_prune_test.go
+++ b/internal/image_prune_test.go
@@ -1,0 +1,238 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/docker/api/types/image"
+)
+
+// pruneTestProject returns a project with a build service (web, defaulting to
+// the <project>-web image) and a service with an explicit image (api).
+func pruneTestProject() *types.Project {
+	return &types.Project{
+		Services: types.Services{
+			"web": types.ServiceConfig{Name: "web"},
+			"api": types.ServiceConfig{Name: "api", Image: "myapp:latest"},
+		},
+	}
+}
+
+// pruneInspectByName maps resolved image names to IDs for the keep-set lookup.
+func pruneInspectByName(ids map[string]string) func(ctx context.Context, imageID string) (image.InspectResponse, error) {
+	return func(ctx context.Context, imageID string) (image.InspectResponse, error) {
+		if id, ok := ids[imageID]; ok {
+			return image.InspectResponse{ID: id}, nil
+		}
+		return image.InspectResponse{}, fmt.Errorf("no such image: %s", imageID)
+	}
+}
+
+func TestPruneImagesRemovesLeftovers(t *testing.T) {
+	logger, buf := testLogger()
+
+	var removed []string
+	mockClient := &mockDockerClient{
+		imageInspect: pruneInspectByName(map[string]string{
+			"myproject-web": "sha256:web-current",
+			"myapp:latest":  "sha256:api-current",
+		}),
+		imageList: func(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+			if got := options.Filters.Get("label"); len(got) != 1 || got[0] != "com.docker.compose.project=myproject" {
+				t.Errorf("expected project label filter, got %v", got)
+			}
+			return []image.Summary{
+				{ID: "sha256:web-current", RepoTags: []string{"myproject-web:latest"}},
+				{ID: "sha256:web-old", RepoTags: []string{"<none>:<none>"}},
+				{ID: "sha256:api-current", RepoTags: []string{"myapp:latest"}},
+				{ID: "sha256:api-old", RepoTags: []string{"myapp:v1"}},
+			}, nil
+		},
+		imageRemove: func(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+			removed = append(removed, imageID)
+			return []image.DeleteResponse{{Deleted: imageID}}, nil
+		},
+	}
+
+	pruned, err := PruneImages(context.Background(), PruneImagesInput{
+		Client:      mockClient,
+		Logger:      logger,
+		Project:     pruneTestProject(),
+		ProjectName: "myproject",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pruned) != 2 {
+		t.Fatalf("expected 2 pruned images, got %d (%+v)", len(pruned), pruned)
+	}
+
+	wantRemoved := map[string]bool{"sha256:web-old": true, "sha256:api-old": true}
+	if len(removed) != 2 {
+		t.Fatalf("expected 2 removals, got %v", removed)
+	}
+	for _, id := range removed {
+		if !wantRemoved[id] {
+			t.Errorf("unexpected removal of %s", id)
+		}
+	}
+	for _, id := range removed {
+		if id == "sha256:web-current" || id == "sha256:api-current" {
+			t.Errorf("current image %s must not be removed", id)
+		}
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Removed image") {
+		t.Errorf("expected removal log output, got %q", out)
+	}
+}
+
+func TestPruneImagesSkipsInUseImage(t *testing.T) {
+	logger, buf := testLogger()
+
+	mockClient := &mockDockerClient{
+		imageInspect: pruneInspectByName(map[string]string{}),
+		imageList: func(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+			return []image.Summary{
+				{ID: "sha256:inuse", RepoTags: []string{"<none>:<none>"}},
+			}, nil
+		},
+		imageRemove: func(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+			return nil, fmt.Errorf("conflict: image is being used by running container abc123")
+		},
+	}
+
+	pruned, err := PruneImages(context.Background(), PruneImagesInput{
+		Client:      mockClient,
+		Logger:      logger,
+		Project:     pruneTestProject(),
+		ProjectName: "myproject",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pruned) != 0 {
+		t.Errorf("expected no pruned images, got %+v", pruned)
+	}
+	if out := buf.String(); !strings.Contains(out, "Skipping image") {
+		t.Errorf("expected skip warning in log, got %q", out)
+	}
+}
+
+func TestPruneImagesDryRun(t *testing.T) {
+	logger, buf := testLogger()
+
+	mockClient := &mockDockerClient{
+		imageInspect: pruneInspectByName(map[string]string{}),
+		imageList: func(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+			return []image.Summary{
+				{ID: "sha256:leftover", RepoTags: []string{"<none>:<none>"}},
+			}, nil
+		},
+		imageRemove: func(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+			t.Fatalf("ImageRemove must not be called in dry-run mode")
+			return nil, nil
+		},
+	}
+
+	pruned, err := PruneImages(context.Background(), PruneImagesInput{
+		Client:      mockClient,
+		DryRun:      true,
+		Logger:      logger,
+		Project:     pruneTestProject(),
+		ProjectName: "myproject",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pruned) != 1 || pruned[0].ID != "sha256:leftover" {
+		t.Errorf("expected leftover to be reported, got %+v", pruned)
+	}
+	if out := buf.String(); !strings.Contains(out, "Would remove image") {
+		t.Errorf("expected dry-run log, got %q", out)
+	}
+}
+
+func TestPruneImagesNoCandidates(t *testing.T) {
+	logger, _ := testLogger()
+
+	mockClient := &mockDockerClient{
+		imageInspect: pruneInspectByName(map[string]string{}),
+		imageList: func(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+			return nil, nil
+		},
+		imageRemove: func(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+			t.Fatalf("ImageRemove must not be called with no candidates")
+			return nil, nil
+		},
+	}
+
+	pruned, err := PruneImages(context.Background(), PruneImagesInput{
+		Client:      mockClient,
+		Logger:      logger,
+		Project:     pruneTestProject(),
+		ProjectName: "myproject",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pruned) != 0 {
+		t.Errorf("expected no pruned images, got %+v", pruned)
+	}
+}
+
+func TestPruneImagesValidation(t *testing.T) {
+	logger, _ := testLogger()
+
+	tests := []struct {
+		name        string
+		input       PruneImagesInput
+		expectedErr string
+	}{
+		{
+			name:        "missing project name",
+			input:       PruneImagesInput{Client: &mockDockerClient{}, Logger: logger, Project: pruneTestProject()},
+			expectedErr: "project name is required",
+		},
+		{
+			name:        "nil project",
+			input:       PruneImagesInput{Client: &mockDockerClient{}, Logger: logger, ProjectName: "myproject"},
+			expectedErr: "project is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PruneImages(context.Background(), tt.input)
+			if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Errorf("expected error containing %q, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestPruneImagesListError(t *testing.T) {
+	logger, _ := testLogger()
+
+	mockClient := &mockDockerClient{
+		imageInspect: pruneInspectByName(map[string]string{}),
+		imageList: func(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+			return nil, fmt.Errorf("daemon unavailable")
+		},
+	}
+
+	_, err := PruneImages(context.Background(), PruneImagesInput{
+		Client:      mockClient,
+		Logger:      logger,
+		Project:     pruneTestProject(),
+		ProjectName: "myproject",
+	})
+	if err == nil || !strings.Contains(err.Error(), "error listing images") {
+		t.Errorf("expected list error, got %v", err)
+	}
+}

--- a/internal/mocks_test.go
+++ b/internal/mocks_test.go
@@ -27,6 +27,8 @@ type mockDockerClient struct {
 	containerLogs        func(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
 	copyToContainer      func(ctx context.Context, containerID, dstPath string, content io.Reader, options container.CopyToContainerOptions) error
 	imageInspect         func(ctx context.Context, imageID string) (image.InspectResponse, error)
+	imageList            func(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
+	imageRemove          func(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error)
 	eventsFunc           func(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error)
 	renamedContainers    map[string]string
 }
@@ -121,6 +123,20 @@ func (m *mockDockerClient) ImageInspect(ctx context.Context, imageID string) (im
 		return m.imageInspect(ctx, imageID)
 	}
 	return image.InspectResponse{}, nil
+}
+
+func (m *mockDockerClient) ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error) {
+	if m.imageList != nil {
+		return m.imageList(ctx, options)
+	}
+	return nil, nil
+}
+
+func (m *mockDockerClient) ImageRemove(ctx context.Context, imageID string, options image.RemoveOptions) ([]image.DeleteResponse, error) {
+	if m.imageRemove != nil {
+		return m.imageRemove(ctx, imageID, options)
+	}
+	return nil, nil
 }
 
 func (m *mockDockerClient) ContainerLogs(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error) {

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"deploy": func() (cli.Command, error) {
 			return &commands.DeployCommand{Meta: meta}, nil
 		},
+		"image prune": func() (cli.Command, error) {
+			return &commands.ImagePruneCommand{Meta: meta}, nil
+		},
 		"run execute": func() (cli.Command, error) {
 			return &commands.RunExecuteCommand{Meta: meta}, nil
 		},

--- a/test.bats
+++ b/test.bats
@@ -83,6 +83,14 @@ assert_output_not_exists() {
   [[ -z "$output" ]] || flunk "expected no output, found some"
 }
 
+# reset_image_prune removes any containers and images left behind by the
+# image-prune fixture so those tests start from a clean slate and do not leak
+# images into one another.
+reset_image_prune() {
+  docker rm -f $(docker ps -aq --filter "label=com.docker.compose.project=bats-image-prune") >/dev/null 2>&1 || true
+  docker image rm -f $(docker images -aq --filter "label=com.docker.compose.project=bats-image-prune") >/dev/null 2>&1 || true
+}
+
 setup_file() {
   docker pull nginx:latest
 }
@@ -602,6 +610,97 @@ teardown() {
   run docker ps --filter "label=com.docker.compose.project=bats-pull-policy-build" --filter "status=running" -q
   echo "running containers: $output"
   assert_equal "1" "$(echo "$output" | wc -l | tr -d ' ')"
+}
+
+@test "image prune removes leftover images from previous builds" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/image-prune"
+  reset_image_prune
+
+  export TAG=v1
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-image-prune --build --force web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  export TAG=v2
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-image-prune --build --force web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # The previous deploy left bats-image-prune-web:v1 behind, still project-labeled
+  run docker images bats-image-prune-web:v1 -q
+  echo "v1 before prune: $output"
+  [[ -n "$output" ]] || flunk "expected the previous image to be present before prune"
+
+  run "$DOCKER_ORCHESTRATE" image prune --project-name bats-image-prune
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # The leftover image is gone
+  run docker images bats-image-prune-web:v1 -q
+  echo "v1 after prune: $output"
+  assert_equal "" "$output"
+
+  # The current image is kept
+  run docker images bats-image-prune-web:v2 -q
+  echo "v2 after prune: $output"
+  [[ -n "$output" ]] || flunk "expected the current image to be kept"
+
+  reset_image_prune
+}
+
+@test "image prune --dry-run reports without removing" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/image-prune"
+  reset_image_prune
+
+  export TAG=v1
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-image-prune --build --force web
+  assert_success
+
+  export TAG=v2
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-image-prune --build --force web
+  assert_success
+
+  run "$DOCKER_ORCHESTRATE" image prune --project-name bats-image-prune --dry-run
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Would remove image"
+
+  # Dry-run did not remove the leftover
+  run docker images bats-image-prune-web:v1 -q
+  echo "v1 after dry-run: $output"
+  [[ -n "$output" ]] || flunk "expected dry-run to leave the leftover image in place"
+
+  reset_image_prune
+}
+
+@test "deploy --prune-images prunes old images after a rebuild" {
+  cd "${BATS_TEST_DIRNAME}/tests/fixtures/image-prune"
+  reset_image_prune
+
+  export TAG=v1
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-image-prune --build --force web
+  assert_success
+
+  export TAG=v2
+  run "$DOCKER_ORCHESTRATE" deploy --project-name bats-image-prune --build --force --prune-images web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # The deploy pruned the previous image
+  run docker images bats-image-prune-web:v1 -q
+  echo "v1 after prune-images deploy: $output"
+  assert_equal "" "$output"
+
+  # The current image is kept
+  run docker images bats-image-prune-web:v2 -q
+  [[ -n "$output" ]] || flunk "expected the current image to be kept"
+
+  reset_image_prune
 }
 
 @test "x-healthcheck-wait delays before treating container as healthy" {

--- a/tests/fixtures/image-prune/Dockerfile
+++ b/tests/fixtures/image-prune/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:latest
+ARG MARKER
+LABEL bats.marker=${MARKER}

--- a/tests/fixtures/image-prune/docker-compose.yaml
+++ b/tests/fixtures/image-prune/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        MARKER: "${TAG:-v1}"
+    image: "bats-image-prune-web:${TAG:-v1}"
+    pull_policy: build


### PR DESCRIPTION
Adds an `image prune` command that removes images left over from previous builds of a compose project. It keeps the image currently referenced by each service and skips images still in use by a container, scoping cleanup to the project via the compose project label so pulled base images and other projects are never touched. A `--prune-images` flag on `deploy` runs the same cleanup after a successful deploy.

Closes #127