### PR TITLE
chore: format codebase with gofmt and enforce it in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gofmt:
+    name: gofmt
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: "go.mod"
+      - name: Run gofmt
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "These files are not formatted with gofmt:"
+            echo "$unformatted"
+            echo "Run 'gofmt -w .' to fix."
+            exit 1
+          fi
+
   hadolint:
     name: hadolint
     runs-on: ubuntu-24.04

--- a/commands/cron.go
+++ b/commands/cron.go
@@ -43,10 +43,10 @@ func (c *CronCommand) Help() string {
 func (c *CronCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Run cron for a single project":    fmt.Sprintf("%s %s -f docker-compose.yml -p myproject", appName, c.Name()),
-		"Run cron for a config directory":  fmt.Sprintf("%s %s --config-dir /etc/docker-orchestrate", appName, c.Name()),
-		"Run cron with a custom timezone":  fmt.Sprintf("%s %s --config-dir /etc/docker-orchestrate --timezone America/New_York", appName, c.Name()),
-		"Run cron with a reload interval":  fmt.Sprintf("%s %s --config-dir /etc/docker-orchestrate --reload-interval 120s", appName, c.Name()),
+		"Run cron for a single project":   fmt.Sprintf("%s %s -f docker-compose.yml -p myproject", appName, c.Name()),
+		"Run cron for a config directory": fmt.Sprintf("%s %s --config-dir /etc/docker-orchestrate", appName, c.Name()),
+		"Run cron with a custom timezone": fmt.Sprintf("%s %s --config-dir /etc/docker-orchestrate --timezone America/New_York", appName, c.Name()),
+		"Run cron with a reload interval": fmt.Sprintf("%s %s --config-dir /etc/docker-orchestrate --reload-interval 120s", appName, c.Name()),
 	}
 }
 
@@ -80,15 +80,15 @@ func (c *CronCommand) AutocompleteFlags() complete.Flags {
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
 			"--build":           complete.PredictNothing,
-			"--config-dir":     complete.PredictDirs("*"),
-			"--env-file":       complete.PredictFiles("*"),
-			"-f":               complete.PredictFiles("*"),
-			"--file":           complete.PredictFiles("*"),
-			"-p":               complete.PredictAnything,
-			"--project-name":   complete.PredictAnything,
-			"--pull":           complete.PredictSet("always", "missing", "never"),
+			"--config-dir":      complete.PredictDirs("*"),
+			"--env-file":        complete.PredictFiles("*"),
+			"-f":                complete.PredictFiles("*"),
+			"--file":            complete.PredictFiles("*"),
+			"-p":                complete.PredictAnything,
+			"--project-name":    complete.PredictAnything,
+			"--pull":            complete.PredictSet("always", "missing", "never"),
 			"--reload-interval": complete.PredictAnything,
-			"--timezone":       complete.PredictAnything,
+			"--timezone":        complete.PredictAnything,
 		},
 	)
 }

--- a/commands/cron_install.go
+++ b/commands/cron_install.go
@@ -41,10 +41,10 @@ func (c *CronInstallCommand) Help() string {
 func (c *CronInstallCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Install systemd service":                      fmt.Sprintf("%s %s --init systemd -f docker-compose.yml -p myproject", appName, c.Name()),
-		"Install split systemd services":               fmt.Sprintf("%s %s --init systemd --split -f docker-compose.yml -p myproject", appName, c.Name()),
-		"Install runit service":                        fmt.Sprintf("%s %s --init runit -f docker-compose.yml -p myproject", appName, c.Name()),
-		"Dry run to preview generated config":          fmt.Sprintf("%s %s --init systemd --dry-run -f docker-compose.yml -p myproject", appName, c.Name()),
+		"Install systemd service":                        fmt.Sprintf("%s %s --init systemd -f docker-compose.yml -p myproject", appName, c.Name()),
+		"Install split systemd services":                 fmt.Sprintf("%s %s --init systemd --split -f docker-compose.yml -p myproject", appName, c.Name()),
+		"Install runit service":                          fmt.Sprintf("%s %s --init runit -f docker-compose.yml -p myproject", appName, c.Name()),
+		"Dry run to preview generated config":            fmt.Sprintf("%s %s --init systemd --dry-run -f docker-compose.yml -p myproject", appName, c.Name()),
 		"Install systemd service for a config directory": fmt.Sprintf("%s %s --init systemd --config-dir /etc/docker-orchestrate", appName, c.Name()),
 	}
 }

--- a/commands/cron_run.go
+++ b/commands/cron_run.go
@@ -78,15 +78,15 @@ func (c *CronRunCommand) AutocompleteFlags() complete.Flags {
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
 			"--build":           complete.PredictNothing,
-			"--config-dir":     complete.PredictDirs("*"),
-			"--env-file":       complete.PredictFiles("*"),
-			"-f":               complete.PredictFiles("*"),
-			"--file":           complete.PredictFiles("*"),
-			"-p":               complete.PredictAnything,
-			"--project-name":   complete.PredictAnything,
-			"--pull":           complete.PredictSet("always", "missing", "never"),
+			"--config-dir":      complete.PredictDirs("*"),
+			"--env-file":        complete.PredictFiles("*"),
+			"-f":                complete.PredictFiles("*"),
+			"--file":            complete.PredictFiles("*"),
+			"-p":                complete.PredictAnything,
+			"--project-name":    complete.PredictAnything,
+			"--pull":            complete.PredictSet("always", "missing", "never"),
 			"--reload-interval": complete.PredictAnything,
-			"--timezone":       complete.PredictAnything,
+			"--timezone":        complete.PredictAnything,
 		},
 	)
 }

--- a/commands/cron_uninstall.go
+++ b/commands/cron_uninstall.go
@@ -37,11 +37,11 @@ func (c *CronUninstallCommand) Help() string {
 func (c *CronUninstallCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Uninstall systemd service":                 fmt.Sprintf("%s %s --init systemd -p myproject", appName, c.Name()),
-		"Uninstall split systemd services":          fmt.Sprintf("%s %s --init systemd --split -p myproject", appName, c.Name()),
-		"Uninstall runit service":                   fmt.Sprintf("%s %s --init runit -p myproject", appName, c.Name()),
-		"Dry run to preview what would be removed":  fmt.Sprintf("%s %s --init systemd --dry-run -p myproject", appName, c.Name()),
-		"Uninstall including the shared notifier":   fmt.Sprintf("%s %s --init systemd --split --include-notify", appName, c.Name()),
+		"Uninstall systemd service":                fmt.Sprintf("%s %s --init systemd -p myproject", appName, c.Name()),
+		"Uninstall split systemd services":         fmt.Sprintf("%s %s --init systemd --split -p myproject", appName, c.Name()),
+		"Uninstall runit service":                  fmt.Sprintf("%s %s --init runit -p myproject", appName, c.Name()),
+		"Dry run to preview what would be removed": fmt.Sprintf("%s %s --init systemd --dry-run -p myproject", appName, c.Name()),
+		"Uninstall including the shared notifier":  fmt.Sprintf("%s %s --init systemd --split --include-notify", appName, c.Name()),
 	}
 }
 

--- a/commands/run_execute.go
+++ b/commands/run_execute.go
@@ -43,10 +43,10 @@ func (c *RunExecuteCommand) Help() string {
 func (c *RunExecuteCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Run a one-shot service":            fmt.Sprintf("%s %s migrate", appName, c.Name()),
-		"Run a service in detached mode":    fmt.Sprintf("%s %s --detach export", appName, c.Name()),
-		"Build images before running":       fmt.Sprintf("%s %s --build seed", appName, c.Name()),
-		"Run with a specific compose file":  fmt.Sprintf("%s %s -f docker-compose.prod.yaml -p myproject migrate", appName, c.Name()),
+		"Run a one-shot service":           fmt.Sprintf("%s %s migrate", appName, c.Name()),
+		"Run a service in detached mode":   fmt.Sprintf("%s %s --detach export", appName, c.Name()),
+		"Build images before running":      fmt.Sprintf("%s %s --build seed", appName, c.Name()),
+		"Run with a specific compose file": fmt.Sprintf("%s %s -f docker-compose.prod.yaml -p myproject migrate", appName, c.Name()),
 	}
 }
 

--- a/commands/run_list.go
+++ b/commands/run_list.go
@@ -38,7 +38,7 @@ func (c *RunListCommand) Help() string {
 func (c *RunListCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"List one-shot services": fmt.Sprintf("%s %s", appName, c.Name()),
+		"List one-shot services":            fmt.Sprintf("%s %s", appName, c.Name()),
 		"List with a specific compose file": fmt.Sprintf("%s %s -f docker-compose.prod.yaml", appName, c.Name()),
 	}
 }

--- a/commands/run_list_executions.go
+++ b/commands/run_list_executions.go
@@ -33,8 +33,8 @@ func (c *RunListExecutionsCommand) Help() string {
 func (c *RunListExecutionsCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"List all executions":               fmt.Sprintf("%s %s", appName, c.Name()),
-		"List executions for a project":     fmt.Sprintf("%s %s -p myproject", appName, c.Name()),
+		"List all executions":           fmt.Sprintf("%s %s", appName, c.Name()),
+		"List executions for a project": fmt.Sprintf("%s %s -p myproject", appName, c.Name()),
 	}
 }
 

--- a/internal/compose_test.go
+++ b/internal/compose_test.go
@@ -2283,7 +2283,7 @@ func TestPostStartHooksInScaleUp(t *testing.T) {
 			containerInspect: func(ctx context.Context, id string) (container.InspectResponse, error) {
 				return container.InspectResponse{
 					ContainerJSONBase: &container.ContainerJSONBase{
-						ID: id,
+						ID:    id,
 						State: &container.State{Running: true},
 					},
 					Config: &container.Config{
@@ -2529,12 +2529,12 @@ func TestPreStopHooksExecutionOrder(t *testing.T) {
 			CurrentContainers: []container.Summary{
 				{ID: "container1_to_remove", Created: 100},
 			},
-			CurrentReplicas: 1,
-			DesiredReplicas: 0,
-			Executor:        executor,
-			Logger:          logger,
-			ProjectName:     "proj",
-			ServiceName:     "web",
+			CurrentReplicas:    1,
+			DesiredReplicas:    0,
+			Executor:           executor,
+			Logger:             logger,
+			ProjectName:        "proj",
+			ServiceName:        "web",
 			PreStopHostCommand: "echo stopping",
 			PreStopCommand:     "#!/bin/sh\necho bye",
 			PreStopHooks: []composeTypes.ServiceHook{
@@ -2949,16 +2949,16 @@ func TestScaleUpContainersWaitAfterHealthy(t *testing.T) {
 		}
 
 		input := ScaleUpContainersInput{
-			Client:          mock,
-			Executor:        executor,
-			Logger:          logger,
-			ProjectName:     "proj",
-			ProjectDir:      "/tmp",
-			ServiceName:     "web",
-			ComposeFiles:    []string{"/tmp/docker-compose.yaml"},
-			Parallelism:     1,
-			CurrentReplicas: 0,
-			DesiredReplicas: 1,
+			Client:           mock,
+			Executor:         executor,
+			Logger:           logger,
+			ProjectName:      "proj",
+			ProjectDir:       "/tmp",
+			ServiceName:      "web",
+			ComposeFiles:     []string{"/tmp/docker-compose.yaml"},
+			Parallelism:      1,
+			CurrentReplicas:  0,
+			DesiredReplicas:  1,
 			WaitAfterHealthy: 4 * time.Second,
 			Sleeper: func(d time.Duration) {
 				sleeperDurations = append(sleeperDurations, d)

--- a/internal/cron_config_test.go
+++ b/internal/cron_config_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestParseCronConfig(t *testing.T) {
 	tests := []struct {
-		name         string
-		extensions   map[string]interface{}
-		defaults     *CronDefaults
-		cliTimezone  string
-		expectNil    bool
-		expectError  bool
-		errContains  string
-		checkConfig  func(t *testing.T, config *CronConfig)
+		name        string
+		extensions  map[string]interface{}
+		defaults    *CronDefaults
+		cliTimezone string
+		expectNil   bool
+		expectError bool
+		errContains string
+		checkConfig func(t *testing.T, config *CronConfig)
 	}{
 		{
 			name: "valid_complete_config",

--- a/internal/cron_every_test.go
+++ b/internal/cron_every_test.go
@@ -112,10 +112,10 @@ func TestMidnightPinnedScheduleNext(t *testing.T) {
 
 func TestParseEveryInterval(t *testing.T) {
 	tests := []struct {
-		name       string
-		schedule   string
-		expectOK   bool
-		expectDur  time.Duration
+		name      string
+		schedule  string
+		expectOK  bool
+		expectDur time.Duration
 	}{
 		{
 			name:      "valid_5m",

--- a/internal/cron_notifier_test.go
+++ b/internal/cron_notifier_test.go
@@ -861,4 +861,3 @@ func TestCronNotifierRun(t *testing.T) {
 		_ = err
 	})
 }
-

--- a/internal/deploy_test.go
+++ b/internal/deploy_test.go
@@ -275,11 +275,11 @@ func TestDeployServiceStopGracePeriod(t *testing.T) {
 
 func TestDeployServiceCleansUpNonRunningContainers(t *testing.T) {
 	tests := []struct {
-		name               string
-		allContainers      []container.Summary
-		expectedRemovals   []string
-		removeError        error
-		expectDeployError  bool
+		name              string
+		allContainers     []container.Summary
+		expectedRemovals  []string
+		removeError       error
+		expectDeployError bool
 	}{
 		{
 			name: "removes_exited_containers",

--- a/internal/run.go
+++ b/internal/run.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/josegonzalez/cli-skeleton/command"
 )
 

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -597,8 +597,8 @@ func TestListRunExecutions(t *testing.T) {
 		containerList: func(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
 			return []container.Summary{
 				{
-					Names: []string{"/test-seed-20260407-143022-ab3f"},
-					State: "exited",
+					Names:  []string{"/test-seed-20260407-143022-ab3f"},
+					State:  "exited",
 					Status: "Exited (0) 5 minutes ago",
 					Labels: map[string]string{
 						"com.dokku.orchestrate/run":              "true",


### PR DESCRIPTION
Formats the entire Go codebase with `gofmt` and adds a `gofmt` job to the lint workflow that fails when any file is not formatted, so formatting drift is caught in CI going forward.